### PR TITLE
t5-large and t5-3b work

### DIFF
--- a/examples/hf/translation/run_translation.py
+++ b/examples/hf/translation/run_translation.py
@@ -375,6 +375,9 @@ def run_master(pp_ranks, training_args, model_args, data_args):
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
+    # We do not support outputting `past_key_values` currently. See comment below re `output_chunk_spec`
+    if hasattr(config, 'use_cache'):
+        config.use_cache = False
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path,
         cache_dir=model_args.cache_dir,
@@ -401,9 +404,14 @@ def run_master(pp_ranks, training_args, model_args, data_args):
         output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b),
                              'logits': TensorChunkSpec(0),
                              'encoder_last_hidden_state': TensorChunkSpec(0),
-                             'past_key_values': [
-                                 [TensorChunkSpec(0) for _ in range(model.config.num_decoder_layers)] for _ in range(4)
-                             ]}
+                             # past_key_values, optional, returned when use_cache=True is passed or when
+                             # config.use_cache=True. Outputting past_key_values for t5-large or t5-3b incurs many
+                             # getitem calls, which may lead to hang, disabling for now
+                             # TODO: enable
+                             #'past_key_values': [
+                             #    [TensorChunkSpec(0) for _ in range(model.config.num_decoder_layers)] for _ in range(4)
+                             #]
+                            }
     else:
         output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b),
                              'logits': TensorChunkSpec(0),
@@ -612,6 +620,7 @@ def run_master(pp_ranks, training_args, model_args, data_args):
 
     # Initialize our Trainer
     # =============================================== PiPPy change start ===============================================
+    logger.info(f'[PiPPy] Creating PiPPySeq2SeqTrainer ...')
     trainer = PiPPySeq2SeqTrainer(
     # ================================================ PiPPy change end ================================================
         model=model,

--- a/examples/hf/translation/t5-3b_config.json
+++ b/examples/hf/translation/t5-3b_config.json
@@ -1,0 +1,58 @@
+{
+    "architectures": [
+    "T5WithLMHeadModel"
+    ],
+    "d_ff": 16384,
+    "d_kv": 128,
+    "d_model": 1024,
+    "decoder_start_token_id": 0,
+    "dense_act_fn": "relu",
+    "dropout_rate": 0.1,
+    "eos_token_id": 1,
+    "feed_forward_proj": "relu",
+    "initializer_factor": 1.0,
+    "is_encoder_decoder": true,
+    "is_gated_act": false,
+    "layer_norm_epsilon": 1e-06,
+    "model_type": "t5",
+    "n_positions": 512,
+    "num_decoder_layers": 24,
+    "num_heads": 32,
+    "num_layers": 24,
+    "output_past": true,
+    "pad_token_id": 0,
+    "relative_attention_max_distance": 128,
+    "relative_attention_num_buckets": 32,
+    "task_specific_params": {
+    "summarization": {
+        "early_stopping": true,
+        "length_penalty": 2.0,
+        "max_length": 200,
+        "min_length": 30,
+        "no_repeat_ngram_size": 3,
+        "num_beams": 4,
+        "prefix": "summarize: "
+    },
+    "translation_en_to_de": {
+        "early_stopping": true,
+        "max_length": 300,
+        "num_beams": 4,
+        "prefix": "translate English to German: "
+    },
+    "translation_en_to_fr": {
+        "early_stopping": true,
+        "max_length": 300,
+        "num_beams": 4,
+        "prefix": "translate English to French: "
+    },
+    "translation_en_to_ro": {
+        "early_stopping": true,
+        "max_length": 300,
+        "num_beams": 4,
+        "prefix": "translate English to Romanian: "
+    }
+    },
+    "transformers_version": "4.22.0.dev0",
+    "use_cache": false,
+    "vocab_size": 32128
+}

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -942,6 +942,7 @@ class PipelineDriverBase(torch.nn.Module):
             assert len(self.all_ranks) == self.world_size, "Explicitly specified ranks must match world_size"
         else:
             self.all_ranks = list(range(self.world_size))
+        logging.info(f'[root] Creating pipeline driver with {self.world_size} workers: {self.all_ranks}')
 
         class ExecutorDescriptor:
             name : str

--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -274,6 +274,7 @@ class PiPPyHFTracer(fx.HFTracer):
 
 def wrap(model, training_args, pp_ranks, args_chunk_spec, kwargs_chunk_spec, output_chunk_spec):
     model.to(training_args.device)
+    logger.info(f'[PiPPy] Splitting model ...')
     model_to_wrap[model.__class__.__name__](model, training_args, pp_ranks)
 
     all_worker_ranks = pp_ranks[training_args.exclude_master:]
@@ -284,10 +285,13 @@ def wrap(model, training_args, pp_ranks, args_chunk_spec, kwargs_chunk_spec, out
     MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
     output_loss_value_spec = {k: isinstance(v, CustomReducer) for k, v in output_chunk_spec.items()}
     model_config = model.config
+
+    logger.info(f'[PiPPy] Creating pipeline ...')
     model = Pipe.from_tracing(model, MULTI_USE_PARAM_CONFIG, tracer=PiPPyHFTracer(), concrete_args=concrete_args,
                               output_loss_value_spec=output_loss_value_spec)
     model.config = model_config
 
+    logger.info(f'[PiPPy] Initializing pipeline driver ...')
     model = PipelineDriverFillDrain(model, training_args.chunks or len(all_worker_ranks),
                                     args_chunk_spec, kwargs_chunk_spec, output_chunk_spec,
                                     world_size=len(all_worker_ranks),

--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -274,7 +274,7 @@ class PiPPyHFTracer(fx.HFTracer):
 
 def wrap(model, training_args, pp_ranks, args_chunk_spec, kwargs_chunk_spec, output_chunk_spec):
     model.to(training_args.device)
-    logger.info(f'[PiPPy] Splitting model ...')
+    logger.info('[PiPPy] Splitting model ...')
     model_to_wrap[model.__class__.__name__](model, training_args, pp_ranks)
 
     all_worker_ranks = pp_ranks[training_args.exclude_master:]
@@ -286,12 +286,12 @@ def wrap(model, training_args, pp_ranks, args_chunk_spec, kwargs_chunk_spec, out
     output_loss_value_spec = {k: isinstance(v, CustomReducer) for k, v in output_chunk_spec.items()}
     model_config = model.config
 
-    logger.info(f'[PiPPy] Creating pipeline ...')
+    logger.info('[PiPPy] Creating pipeline ...')
     model = Pipe.from_tracing(model, MULTI_USE_PARAM_CONFIG, tracer=PiPPyHFTracer(), concrete_args=concrete_args,
                               output_loss_value_spec=output_loss_value_spec)
     model.config = model_config
 
-    logger.info(f'[PiPPy] Initializing pipeline driver ...')
+    logger.info('[PiPPy] Initializing pipeline driver ...')
     model = PipelineDriverFillDrain(model, training_args.chunks or len(all_worker_ranks),
                                     args_chunk_spec, kwargs_chunk_spec, output_chunk_spec,
                                     world_size=len(all_worker_ranks),

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -7,15 +7,11 @@ import torch
 import torch.multiprocessing as mp
 import torch.distributed.rpc as rpc
 
-import pippy.fx
-
 
 VERBOSE = bool(int(os.environ.get('VERBOSE', False)))
 
 if VERBOSE:
     logging.getLogger().setLevel(logging.DEBUG)
-
-pippy.fx.Tracer.proxy_buffer_attributes = True
 
 
 def has_efa() -> bool:


### PR DESCRIPTION
`past_key_values`, optional, returned when `use_cache=True` is passed or when `config.use_cache=True`. 

Outputting `past_key_values` for t5-large or t5-3b incurs many `getitem` calls, which may lead to hang, disabling for now.
