### PR TITLE
[spmd] add more reshard suggestions to einop_rule

### DIFF
--- a/spmd/tensor/ops/math_ops.py
+++ b/spmd/tensor/ops/math_ops.py
@@ -18,6 +18,27 @@ def _gen_spec_with_pending_sum(
     )
 
 
+def _gen_reshard_suggestions(
+    input_dims: List[str],
+    input_specs: List[DTensorSpec],
+    dim_to_sharding: Dict[str, int],
+    pending_sum: List[int],
+):
+    suggested_arg_specs = []
+    for input_dim, input_spec in zip(input_dims, input_specs):
+        dim_map = [dim_to_sharding[dim] for dim in input_dim]
+        suggested_arg_specs.append(
+            DTensorSpec.from_dim_map(
+                mesh=input_spec.mesh, dim_map=dim_map, sums=pending_sum
+            )
+        )
+    return OutputSharding(
+        None,
+        schema_suggestions=[OpSchema(suggested_arg_specs, {})],
+        failed_reason="Input placements op sharding propagation failed, need to reshard!",
+    )
+
+
 def einop_rule(
     equation: str, op_schema: OpSchema, linearity: bool = False
 ) -> OutputSharding:
@@ -43,6 +64,7 @@ def einop_rule(
     dim_to_sharding: Dict[str, int] = {}
     pending_sums: List[int] = []
     seen_shardings = {}
+    needs_reshard = False
     # partial_linearity means if the op support linearity, and there exist
     # partial placements, all placements on the mesh dim should be partial
     partial_linearity = True
@@ -83,6 +105,23 @@ def einop_rule(
             failed_reason="Input placements does not satisfy linearity property of the op!",
         )
 
+    def merge_sharding(dim, a, b):
+        # merge the sharding of inputs if it's able to merge, i.e. we can merge
+        # replicate and shard to shard, but this will trigger an reshard operation
+        if a != b:
+            if a == -1 or b == -1:
+                # rehsard the replicate to match the sharded one
+                nonlocal needs_reshard
+                needs_reshard = True
+                return a if a != -1 else b
+            else:
+                # TODO: further merge the sharding properly (i.e. reshard one input to replicate)
+                raise RuntimeError(
+                    f"{equation}: dim {dim} sharded two different ways: {a} and {b}"
+                )
+        else:
+            return a
+
     for input_dim, input_spec in zip(input_dims, input_specs):
         for dim, mesh_dim in zip(input_dim, input_spec.dim_map):
             if (
@@ -99,11 +138,17 @@ def einop_rule(
             if dim not in dim_to_sharding:
                 dim_to_sharding[dim] = mesh_dim
             else:
-                # TODO: merge the sharding properly, if cann't be merged, return suggestion
-                assert (
-                    dim_to_sharding[dim] == mesh_dim
-                ), f"{equation}: dim {dim} sharded two different ways: {mesh_dim} and {dim_to_sharding[dim]}"
+                dim_to_sharding[dim] = merge_sharding(
+                    dim, dim_to_sharding[dim], mesh_dim
+                )
 
+    if needs_reshard:
+        # TODO: merge this logic with partial linearity checks
+        return _gen_reshard_suggestions(
+            input_dims, input_specs, dim_to_sharding, pending_sums
+        )
+
+    # if no need to reshard, we directly generate the output sharding
     for dim, shard_on_mesh in dim_to_sharding.items():
         if dim not in output_dims[0] and shard_on_mesh != -1:
             pending_sums.append(shard_on_mesh)

--- a/test/spmd/tensor/test_dtensor_ops.py
+++ b/test/spmd/tensor/test_dtensor_ops.py
@@ -284,7 +284,6 @@ dtensor_fails = {
     xfail("index_put"),
     xfail("index_reduce"),
     xfail("index_select"),
-    xfail("inner"),
     xfail("isfinite"),
     xfail("isin"),
     xfail("isinf"),

--- a/test/spmd/tensor/test_math_ops.py
+++ b/test/spmd/tensor/test_math_ops.py
@@ -143,12 +143,12 @@ class DistMathOpsTest(DistTensorTestBase):
         with self.assertRaisesRegex(RuntimeError, "across the same mesh dim!"):
             einop_rule("mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {}))
 
-        mat1, mat2 = [0, -1], [-1, -1]
+        mat1, mat2 = [0, -1], [1, -1]
         mat1_spec = DTensorSpec.from_dim_map(mesh, mat1, [])
         mat2_spec = DTensorSpec.from_dim_map(mesh, mat2, [])
 
         with self.assertRaisesRegex(
-            AssertionError, "sharded two different ways:"
+            RuntimeError, "sharded two different ways:"
         ):
             einop_rule("ij,ij->ij", OpSchema((mat1_spec, mat2_spec), {}))
 


### PR DESCRIPTION
This PR add reshard suggestions to einop rule, namely if we found
that the same tensor dimension is both replicated and sharded across
different inputs, we return the reshard suggestions to reshard the
replicated input to sharded. Taking an example:

If we call `bmm(replicate, shard(0))`, we should make the first one
be also shard on the batch dimension by performing a zero cost reshard

This rule is general to all einop related rule, as long as the named
dimension of inputs are the same, added tests to test bmm and baddbmm
works

TODO: merge the reshard suggestions on this with the partial linear reshard suggestions.