### PR TITLE
[dtensor] support implicit broadcasting for pointwise ops

### DIFF
--- a/spmd/tensor/ops/pointwise_ops.py
+++ b/spmd/tensor/ops/pointwise_ops.py
@@ -167,13 +167,15 @@ def pointwise_rule(
         # we mark the dim char as a special "1" to distinguish with
         # the non-singleton dimension, so that sharding propagation
         # should just ignore the singleton dimension.
-        for i, dim_length in enumerate(input.shape):
-            if dim_length == 1:
-                # mark singleton dim char as a special "1" in einop rule
-                p = p[:i] + "1" + p[i + 1 :]
+        if len(input_specs) > 1:
+            for i, dim_length in enumerate(input.shape):
+                if dim_length == 1:
+                    # mark singleton dim char as a special "1" in einop rule
+                    p = p[:i] + "1" + p[i + 1 :]
         dimchars.append(p)
     out_dimchars = alphabet[:max_dim]
     fmt = f"{','.join(p for p in dimchars)}->{out_dimchars}"
+    print(f">>>> fmt: {fmt}")
     return einop_rule(fmt, op_schema, linearity=linearity)
 
 

--- a/spmd/tensor/ops/pointwise_ops.py
+++ b/spmd/tensor/ops/pointwise_ops.py
@@ -183,6 +183,8 @@ def pointwise_rule(
                     p = _replace_char_in_str(p, "1", i)
         dimchars.append(p)
     out_dimchars = alphabet[:max_dim]
+    # check if we replace the all inputs dim char with singleton dimension,
+    # if we replace all inputs, we also need to replace the output dimension.
     for output_dim_idx in range(len(out_dimchars)):
         out_dimchar = out_dimchars[output_dim_idx]
         if dimchar_singleton_counter.get(out_dimchar, 0) == len(input_specs):

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 from torch.testing._internal.common_utils import run_tests
-from spmd.tensor import distribute_tensor
 from spmd.testing.common_utils import (  # type: ignore
     DistTensorTestBase,
     with_comms,

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 from torch.testing._internal.common_utils import run_tests
+from spmd.tensor import distribute_tensor
 from spmd.testing.common_utils import (  # type: ignore
     DistTensorTestBase,
     with_comms,


### PR DESCRIPTION
This PR support implicit broadcasting for pointwise ops, where it is able to propagate the sharding of "broadcasting to a common shape" case.

When the dimension of a input is 1, we mark it explictly during propagation, so that the sharding can be propagated without trying to reshard i.e.
input0 (8, 4, 8), input 1(8, 1, 8), if we shard on input0 dim 1, it could directly propagate the sharding without leeting input 1 be also shard on dim1

NOTE that since the op rules might be used by some chained suggestions (i.e. addmm or baddbmm chained suggestion), one spec might be the output of a sharding propagation, so it must have shape there to validate if there's singleton dimension. As a result, this PR forces sharding propagation rules to generate correct output shape