### PR TITLE
[dtensor] let sample inputs requires_grad directly

### DIFF
--- a/test/spmd/tensor/test_dtensor_ops.py
+++ b/test/spmd/tensor/test_dtensor_ops.py
@@ -677,9 +677,11 @@ def run_dtensor_crossref(test_case, func, args, kwargs):
     rs = func(*args, **kwargs)
 
     def to_replicate(e: object) -> object:
-        return e.redistribute(
-                test_case.mesh, test_case.mesh.ndim * [Replicate()]
-            ) if isinstance(e, DTensor) else e
+        return (
+            e.redistribute(test_case.mesh, test_case.mesh.ndim * [Replicate()])
+            if isinstance(e, DTensor)
+            else e
+        )
 
     try:
         # Suppress warnings, this doesn't matter for test_meta.py


### PR DESCRIPTION
It seems like op db could generate requires_grad inputs directly, so switching to use this instead of manually set requires_grad