### PR TITLE
Add CUDA device pinning

### DIFF
--- a/examples/hf/translation/run_translation.py
+++ b/examples/hf/translation/run_translation.py
@@ -25,6 +25,9 @@ import types
 from dataclasses import dataclass, field
 from typing import Optional
 
+# Run before `import torch` to pin CUDA devices first
+from pippy import run_pippy
+
 import datasets
 import numpy as np
 import torch
@@ -50,7 +53,6 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version, send_example_telemetry
 from transformers.utils.versions import require_version
 
-from pippy import run_pippy
 from pippy.hf import PiPPySeq2SeqTrainingArguments, PiPPySeq2SeqTrainer, wrap
 from pippy.microbatch import TensorChunkSpec, CustomReducer
 

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -3,6 +3,18 @@ import os
 import socket
 import logging
 
+# Pinning process to a separate GPU if not yet done by launch script
+# Notes:
+# 1. Needed to work around the issue of RPC not automatically pinning spawned worker threads to CUDA device of the main
+# thread
+# 2. Must be done before `import torch` at which point CUDA context may be created
+if ('CUDA_VISIBLE_DEVICES' not in os.environ                        # not set
+        or len(os.getenv('CUDA_VISIBLE_DEVICES').split(',')) > 1):  # or set to all devices
+    # If launchers like Torchrun sets `LOCAL_RANK`, we would use this information
+    if 'LOCAL_RANK' in os.environ:
+        os.environ['CUDA_VISIBLE_DEVICES'] = os.getenv('LOCAL_RANK')
+        print(f"Pinning local process {os.getenv('LOCAL_RANK')} to gpu {os.getenv('CUDA_VISIBLE_DEVICES')}")
+
 import torch
 import torch.multiprocessing as mp
 import torch.distributed.rpc as rpc
@@ -80,6 +92,8 @@ def run_worker(rank, run_master, args, *extra_args):
             dev_id = rank % n_devs
             for i in range(actual_world_size):
                 options.set_device_map(f"worker{i}", {dev_id: i % n_devs})
+            # Does not seem effective for RPC device pinning. TODO
+            # options.set_devices([f'cuda:{dev_id}'])
         else:
             args.cuda = 0
             print('Warning: no CUDA device found. Running on CPU instead.')

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -8,12 +8,14 @@ import logging
 # 1. Needed to work around the issue of RPC not automatically pinning spawned worker threads to CUDA device of the main
 # thread
 # 2. Must be done before `import torch` at which point CUDA context may be created
-if ('CUDA_VISIBLE_DEVICES' not in os.environ                        # not set
-        or len(os.getenv('CUDA_VISIBLE_DEVICES').split(',')) > 1):  # or set to all devices
+cuda_devices_str = os.getenv('CUDA_VISIBLE_DEVICES')
+if (cuda_devices_str is None                        # not set
+        or len(cuda_devices_str.split(',')) > 1):   # or set to all devices
     # If launchers like Torchrun sets `LOCAL_RANK`, we would use this information
-    if 'LOCAL_RANK' in os.environ:
-        os.environ['CUDA_VISIBLE_DEVICES'] = os.getenv('LOCAL_RANK')
-        print(f"Pinning local process {os.getenv('LOCAL_RANK')} to gpu {os.getenv('CUDA_VISIBLE_DEVICES')}")
+    local_rank_str = os.getenv('LOCAL_RANK')
+    if local_rank_str is not None:
+        os.environ['CUDA_VISIBLE_DEVICES'] = local_rank_str
+        print(f"Pinning local process {local_rank_str} to gpu {os.getenv('CUDA_VISIBLE_DEVICES')}")
 
 import torch
 import torch.multiprocessing as mp


### PR DESCRIPTION
to avoid extra CUDA contexts on the default cuda:0

Test:
```torchrun --nproc_per_node=8 --nnodes=1 --node_rank=0 --master_addr="localhost" --master_port=23456 run_translation.py --model_name_or_path t5-3b --do_train --source_lang en --target_lang ro   --source_prefix "translate English to Romanian: " --dataset_name wmt16 --dataset_config_name ro-en   --output_dir /tmp/tst-translation-gpu --per_device_train_batch_size=8 --per_device_eval_batch_size=8   --overwrite_output_dir --predict_with_generate --max_steps=10   --dp_group_size=1 --pp_group_size=8 --config_name=t5-3b_config.json```

Output:
```
Pinning local process 5 to gpu 5
Pinning local process 7 to gpu 7
Pinning local process 4 to gpu 4
Pinning local process 1 to gpu 1
Pinning local process 0 to gpu 0
Pinning local process 3 to gpu 3
Pinning local process 6 to gpu 6
Pinning local process 2 to gpu 2
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 7 host/pid/device = dev-st-p3dn24xlarge-1/66086/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 5 host/pid/device = dev-st-p3dn24xlarge-1/66084/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 2 host/pid/device = dev-st-p3dn24xlarge-1/66081/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 4 host/pid/device = dev-st-p3dn24xlarge-1/66083/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 6 host/pid/device = dev-st-p3dn24xlarge-1/66085/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 1 host/pid/device = dev-st-p3dn24xlarge-1/66080/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 0 host/pid/device = dev-st-p3dn24xlarge-1/66079/cuda:0
[PiPPy] World size: 8, DP group size: 1, PP group size: 8
rank = 3 host/pid/device = dev-st-p3dn24xlarge-1/66082/cuda:0
```

Otherwise, we will run into CUDA OOM.