### PR TITLE
Remove deprecated eig

### DIFF
--- a/spmd/testing/dtensor_lagging_op_db.py
+++ b/spmd/testing/dtensor_lagging_op_db.py
@@ -147,7 +147,6 @@ _dtensor_lagging_meta = {
     ("double", ""),
     ("dsplit", ""),
     ("dstack", ""),
-    ("eig", ""),
     ("einsum", ""),
     ("empty", ""),
     ("empty_like", ""),

--- a/test/spmd/tensor/test_dtensor_ops.py
+++ b/test/spmd/tensor/test_dtensor_ops.py
@@ -197,7 +197,6 @@ dtensor_fails = {
     xfail("dot"),
     xfail("dsplit"),
     xfail("dstack"),
-    xfail("eig"),
     xfail("einsum"),
     xfail("empty"),
     xfail("empty_like"),


### PR DESCRIPTION
`eig` is removed from PyTorch by
https://github.com/pytorch/pytorch/pull/70982. Update spmd accordingly.