### PR TITLE
Add more context for sharding propagation failures

### DIFF
--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -153,7 +153,14 @@ def operator_dispatch(
     # step 1. there's sharding propagation rule, run
     # sharding propagation to get output sharding
     if sharding_prop_func is not None:
-        output_sharding = sharding_prop_func(op_schema)
+        try:
+            output_sharding = sharding_prop_func(op_schema)
+        except Exception as e:
+            raise RuntimeError(
+                f"Sharding propagation failed on op {op_key}.\n"
+                f"Input schema: {op_schema}.\n"
+                f"Error: {e}"
+            )
 
         # step 2. if can't get output_spec from sharding
         # propagation (i.e. no rules apply for input

--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -160,7 +160,7 @@ def operator_dispatch(
                 f"Sharding propagation failed on op {op_key}.\n"
                 f"Input schema: {op_schema}.\n"
                 f"Error: {e}"
-            )
+            ) from e
 
         # step 2. if can't get output_spec from sharding
         # propagation (i.e. no rules apply for input

--- a/test/spmd/tensor/test_math_ops.py
+++ b/test/spmd/tensor/test_math_ops.py
@@ -53,7 +53,7 @@ class DistMathOpsTest(DistTensorTestBase):
             dist_x = distribute_tensor(x, device_mesh, [Shard(shard_dim)])
             if dims[shard_dim] == dims[softmax_dim]:
                 with self.assertRaisesRegex(
-                    Exception, "^Cannot run .* on sharding dimension!$"
+                    Exception, "Cannot run .* on sharding dimension!$"
                 ):
                     dist_y = torch.nn.functional.softmax(
                         dist_x, dim=softmax_dim, dtype=torch.float32
@@ -93,7 +93,7 @@ class DistMathOpsTest(DistTensorTestBase):
             self.assertTrue(dist_x.requires_grad)
             if dims[softmax_dim] == dims[shard_dim]:
                 with self.assertRaisesRegex(
-                    Exception, "^Cannot run .* on sharding dimension!$"
+                    Exception, "Cannot run .* on sharding dimension!$"
                 ):
                     dist_softmax = dist_x.softmax(dim=softmax_dim)
             else:


### PR DESCRIPTION
This will make it a bit easier to improve sharding propagation, specially on the backward pass where we don't have python stack trace of the call.