### PR TITLE
pin python version for linter ci until mypy fix

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: ['3.10.6']
     - name: Install dependencies
       run: |
         pip install --upgrade pip


### PR DESCRIPTION
mypy failed on python 3.10.7, so pin python version until that mypy fix get released. https://github.com/python/mypy/issues/13627