### PR TITLE
Fix improper tuple constructor bug in instantiate_device_type_tests()

### DIFF
--- a/test/spmd/tensor/test_dtensor_ops.py
+++ b/test/spmd/tensor/test_dtensor_ops.py
@@ -691,7 +691,7 @@ class TestDTensorOps(DistTensorTestBase):
 
 
 # only instantiate tests for DEVICE_TYPE alone (i.e. either CPU or GPU)
-instantiate_device_type_tests(TestDTensorOps, globals(), only_for=(DEVICE_TYPE))
+instantiate_device_type_tests(TestDTensorOps, globals(), only_for=(DEVICE_TYPE,))
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/test_dtensor_ops.py
+++ b/test/spmd/tensor/test_dtensor_ops.py
@@ -31,7 +31,7 @@ from spmd.testing.common_utils import (
 
 
 DEVICE_TYPE = "cuda" if torch.cuda.is_available() else "cpu"
-NUM_DEVICES = 4
+NUM_DEVICES = min(4, torch.cuda.device_count())
 
 # rewrite common size variables to sth can be sharded evenly
 # we can enable uneven shards later, but need to adjust more on
@@ -691,7 +691,9 @@ class TestDTensorOps(DistTensorTestBase):
 
 
 # only instantiate tests for DEVICE_TYPE alone (i.e. either CPU or GPU)
-instantiate_device_type_tests(TestDTensorOps, globals(), only_for=(DEVICE_TYPE,))
+instantiate_device_type_tests(
+    TestDTensorOps, globals(), only_for=(DEVICE_TYPE,)
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`only_for` should be treated as an `Optional[<Container>]`; is an optional container.

This code treats `(<V>)` as a tuple constructor, but it is not.

The resulting call was broken:
```
DEVICE_TYPE : str = "cuda"

E := (DEVICE_TYPE)
E ~= DEVICE_TYPE
E : str
```

When `instantiate_device_type_tests()>filter_desired_device_types()` calls:
```
if only_for:
  ... = filter(lambda x: x.device_type in only_for, ...)
```

the device type is checked via substring inclusion, not container inclusion.
("cuda" is a substring of "cuda")

It is entirely an accident that this works; the pytorch testing code should be enforcing a proper container here.