### PR TITLE
DeviceMesh MeshExprT type cleanup.

### DIFF
--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import warnings
-from typing import List, Optional, Iterable, Sequence
+from typing import List, Optional, Iterable, Sequence, TypeVar, Union
 import torch
 import torch.nn.functional as F
 from torch.distributed._spmd.comm_tensor import CommTensor
@@ -34,6 +34,19 @@ def get_global_device_mesh() -> "DeviceMesh":
 def set_global_device_mesh(mesh: Optional["DeviceMesh"]) -> None:
     global _global_device_mesh
     _global_device_mesh = mesh
+
+
+# We want a type for "can be passed to torch.as_tensor()";
+# this is a recursive sequence type, which isn't fully supported
+# yet in python. This construct simulates that up to depth 7.
+T = TypeVar("T")
+_L = Union[T, Sequence[T]]
+NDIntList = _L[_L[_L[_L[_L[_L[_L[int]]]]]]]
+
+MeshExprT = Union[
+    torch.Tensor,
+    NDIntList,
+]
 
 
 class DeviceMesh(object):
@@ -85,18 +98,19 @@ class DeviceMesh(object):
     mesh: torch.Tensor
     _backend: str
 
+    @classmethod
+    def _copy_mesh(cls, mesh: MeshExprT) -> torch.Tensor:
+        return torch.as_tensor(mesh, dtype=torch.int).clone().detach()
+
     def __init__(
         self,
         device_type: str,
-        mesh: Iterable[Sequence[int]],
+        mesh: MeshExprT,
         dim_groups: Optional[List[ProcessGroup]] = None,
     ) -> None:
         self.device_type = device_type
-        self.mesh = (
-            mesh.detach()
-            if isinstance(mesh, torch.Tensor)
-            else torch.tensor(mesh, dtype=torch.int)
-        )
+        self.mesh = self._copy_mesh(mesh)
+
         default_pg = _get_default_group()
         self._backend = default_pg._get_backend_name()
         # TODO: if user want to pass pg_options, offer a way to do it

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import warnings
-from typing import List, Optional, Iterable, Sequence, TypeVar, Union
+from typing import List, Optional, Sequence, TypeVar, Union
 import torch
 import torch.nn.functional as F
 from torch.distributed._spmd.comm_tensor import CommTensor

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -98,10 +98,6 @@ class DeviceMesh(object):
     mesh: torch.Tensor
     _backend: str
 
-    @classmethod
-    def _copy_mesh(cls, mesh: MeshExprT) -> torch.Tensor:
-        return torch.as_tensor(mesh, dtype=torch.int).clone().detach()
-
     def __init__(
         self,
         device_type: str,
@@ -109,8 +105,11 @@ class DeviceMesh(object):
         dim_groups: Optional[List[ProcessGroup]] = None,
     ) -> None:
         self.device_type = device_type
-        self.mesh = self._copy_mesh(mesh)
-
+        self.mesh = (
+            mesh.detach()
+            if isinstance(mesh, torch.Tensor)
+            else torch.tensor(mesh, dtype=torch.int)
+        )
         default_pg = _get_default_group()
         self._backend = default_pg._get_backend_name()
         # TODO: if user want to pass pg_options, offer a way to do it


### PR DESCRIPTION
Cleanup DeviceMesh construction type; remove the need for a lot of ignore pragmas.

Extracted from #481 