### PR TITLE
Land 2D parallel support

### DIFF
--- a/spmd/checkpoint/__init__.py
+++ b/spmd/checkpoint/__init__.py
@@ -1,4 +1,17 @@
-from .utils import (
-    traverse_state_dict,
-    print_tensor
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+from .adv_planner import AdvLoadPlanner, AdvSavePlanner
+
+from .dedup_tensors import dedup_tensors
+
+from .nested_dict import (
+    flatten_state_dict,
+    unflatten_state_dict,
+    FLATTEN_MAPPING,
 )
+
+from .nested_tensor import flatten_sharded_tensors
+
+from .optimizer import load_sharded_optimizer_state_dict
+
+from .traverse import traverse_state_dict, print_tensor

--- a/spmd/checkpoint/__init__.py
+++ b/spmd/checkpoint/__init__.py
@@ -1,0 +1,4 @@
+from .utils import (
+    traverse_state_dict,
+    print_tensor
+)

--- a/spmd/checkpoint/dedup_tensors.py
+++ b/spmd/checkpoint/dedup_tensors.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+from typing import Dict,Any, List, Sequence, Tuple
+import dataclasses
+
+from torch.distributed._shard.checkpoint.planner import SavePlan
+
+def dedup_tensors(all_plans: List[SavePlan]) -> List[SavePlan]:
+    all_plans = list(all_plans)
+    key_to_plan = {}
+    for plan_idx, plan in enumerate(all_plans):
+        for wi in plan.items:
+            key_to_plan.setdefault(wi.index, []).append(plan_idx)
+
+    replicated_items = { k: v for k,v in key_to_plan.items() if len(v) > 1}
+
+    # We're now presented with an interesting choice, how to remove duplicates
+    # We can 1) always keep first entry; 2)randomly keep one entry; 3) load balance across rank
+    # For now we do (1)
+    # Compute the per-rank remove set
+    plan_to_keys = {}
+    for key, plans in replicated_items.items():
+        for plan_idx in plans[1:]:
+            plan_to_keys.setdefault(plan_idx, []).append(key)
+
+    for plan_idx, keys in plan_to_keys.items():
+        key_set = set(keys)
+        # rewrite items and remove elements
+        new_items = [wi for wi in all_plans[plan_idx].items if wi.index not in key_set]
+        all_plans[plan_idx] = dataclasses.replace(all_plans[plan_idx], items=new_items)
+
+    return all_plans

--- a/spmd/checkpoint/nested_dict.py
+++ b/spmd/checkpoint/nested_dict.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+from typing import Dict, Tuple
+
+from torch.distributed._shard.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+"""
+TODO
+handle:
+    tuple
+    OrderedDict
+    NamedTuple
+
+change mappings from dict to a class
+change set_element to recreate the right type (important with tuple, OD and ND)
+
+"""
+
+from .utils import (
+    traverse_state_dict,
+    set_element,
+)
+
+def flatten_state_dict(
+    state_dict: STATE_DICT_TYPE
+) -> Tuple[STATE_DICT_TYPE, Dict[str, Tuple]]:
+    flattened = {}
+    mappings = {}
+
+    def flat_copy(path, value):
+        new_fqn = ".".join(map(str, path))
+        if new_fqn in flattened:
+            raise ValueError(f"duplicated flatten key {new_fqn}")
+        flattened[new_fqn] = value
+        mappings[new_fqn] = path
+
+    traverse_state_dict(state_dict, flat_copy)
+    return flattened, mappings
+
+
+def unflatten_state_dict(
+    state_dict: STATE_DICT_TYPE,
+    mapping: dict[str, Tuple]
+) -> STATE_DICT_TYPE:
+    inflated = {}
+    for key, value in state_dict.items():
+        set_element(inflated, mapping[key], value)
+    return inflated
+

--- a/spmd/checkpoint/nested_dict.py
+++ b/spmd/checkpoint/nested_dict.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 from torch.distributed._shard.checkpoint.metadata import (
     STATE_DICT_TYPE,
 )
+
 """
 TODO
 handle:
@@ -16,18 +17,37 @@ change set_element to recreate the right type (important with tuple, OD and ND)
 
 """
 
-from .utils import (
+from .traverse import (
     traverse_state_dict,
     set_element,
+    OBJ_PATH,
+    STATE_DICT_ITEM,
 )
 
-def flatten_state_dict(
-    state_dict: STATE_DICT_TYPE
-) -> Tuple[STATE_DICT_TYPE, Dict[str, Tuple]]:
-    flattened = {}
-    mappings = {}
+FLATTEN_MAPPING = Dict[str, OBJ_PATH]
+"""
+Type for the flatenning metadata
+"""
 
-    def flat_copy(path, value):
+
+def flatten_state_dict(
+    state_dict: STATE_DICT_TYPE,
+) -> Tuple[STATE_DICT_TYPE, FLATTEN_MAPPING]:
+    """
+    Flatten ``state_dict`` made of nested dicts and lists into a top level dictionary.
+
+    Use ``unflatten_state_dict`` to revert this process.
+
+    Returns:
+        A tuple with the flaten state_dict and a mapping from original to new state_dict.
+
+    N.B. The new keys are derived from the object paths, joined by dot.
+        For example: ``{ 'a': {'b':...}}`` results in the key `a.b`.
+    """
+    flattened: STATE_DICT_TYPE = {}
+    mappings: FLATTEN_MAPPING = {}
+
+    def flat_copy(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
         new_fqn = ".".join(map(str, path))
         if new_fqn in flattened:
             raise ValueError(f"duplicated flatten key {new_fqn}")
@@ -39,11 +59,12 @@ def flatten_state_dict(
 
 
 def unflatten_state_dict(
-    state_dict: STATE_DICT_TYPE,
-    mapping: dict[str, Tuple]
+    state_dict: STATE_DICT_TYPE, mapping: FLATTEN_MAPPING
 ) -> STATE_DICT_TYPE:
-    inflated = {}
+    """
+    Restore the original nested state_dict according to ``mapping`` and the flattened ``state_dict``
+    """
+    inflated: STATE_DICT_TYPE = {}
     for key, value in state_dict.items():
         set_element(inflated, mapping[key], value)
     return inflated
-

--- a/spmd/checkpoint/nested_tensor.py
+++ b/spmd/checkpoint/nested_tensor.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import copy
+from typing import Dict, Tuple
+
+from torch.distributed._shard.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardMetadata,
+    ShardedTensor
+)
+
+from .utils import (
+    traverse_state_dict,
+    set_element,
+    element_wise_add,
+)
+
+def flatten_sharded_tensors(state_dict: Dict[str, Any]) -> Dict[str, Any]:
+    new_state_dict = {}
+
+    def rewrite_dict(path, value):
+        if not isinstance(value, ShardedTensor):
+            set_element(new_state_dict, path, value)
+            return
+        shards = value.local_shards()
+        if len(shards) == 0:
+            return
+        if len(shards) != 1:
+            raise ValueError(f"Cannot handle outer tensor with more than 1 shard {path} -- {len(shards)}")
+        outer_shard = shards[0]
+
+        inner_st = outer_shard.tensor
+        if not isinstance(inner_st, ShardedTensor):
+            set_element(new_state_dict, path, value)
+            return
+
+        if len(inner_st.local_shards()) != 1:
+            raise ValueError("Cannot handle inner tensor with more than 1 shard")
+        inner_shard = inner_st.local_shards()[0]
+
+        local_shards = [
+            Shard(
+                tensor=inner_shard.tensor,
+                metadata=ShardMetadata(
+                    shard_offsets=element_wise_add(
+                        outer_shard.metadata.shard_offsets, 
+                        inner_shard.metadata.shard_offsets),
+                    shard_sizes=inner_shard.metadata.shard_sizes,
+                    placement=f"rank:{dist.get_rank()}/{inner_shard.tensor.device}"
+                ))
+        ]
+
+        st_meta: ShardedTensorMetadata = copy.deepcopy(value.metadata())
+        other_rank = 0 if dist.get_rank() > 0 else 1
+        # Remove the outer ST shard the inner ST covers
+        for i, shard_md in enumerate(st_meta.shards_metadata):
+            if shard_md.shard_offsets == outer_shard.metadata.shard_offsets:
+                st_meta.shards_metadata.pop(i)
+                break
+
+        # blame other rank for the other shards
+        for shard_md in st_meta.shards_metadata:
+            shard_md.placement=_remote_device(f"rank:{other_rank}/cuda:0")
+
+        # Add other inner shards from the inner tensor
+        for inner_md in inner_st.metadata().shards_metadata:
+            if inner_md.shard_offsets != inner_shard.metadata.shard_offsets:
+                st_meta.shards_metadata.append(ShardMetadata(
+                    shard_offsets=element_wise_add(
+                        outer_shard.metadata.shard_offsets, 
+                        inner_md.shard_offsets),
+                    shard_sizes=inner_md.shard_sizes,
+                    placement=f"rank:{other_rank}/cuda:0"
+                ))
+        
+        #finally add this shard
+        st_meta.shards_metadata.append(local_shards[0].metadata)
+        
+        st = ShardedTensor._init_from_local_shards_and_global_metadata(
+            local_shards=local_shards,
+            sharded_tensor_metadata=st_meta,
+        )
+        set_element(new_state_dict, path, st)
+
+    traverse_state_dict(state_dict, rewrite_dict)
+    return new_state_dict

--- a/spmd/checkpoint/optimizer.py
+++ b/spmd/checkpoint/optimizer.py
@@ -1,0 +1,266 @@
+import copy
+import dataclasses
+from functools import reduce, partial
+import io
+import math
+from pickle import FALSE
+from typing import Dict,Any, List, Sequence, Tuple
+from torch.distributed._shard.checkpoint.planner import LoadPlan, ReadItem, SavePlan
+from torch.distributed._shard.sharded_tensor import shard
+
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+import torch.distributed as dist
+import torch.distributed._shard.checkpoint as dist_cp
+from torch.distributed._shard.checkpoint.metadata import BytesStorageMetadata, ChunkStorageMetadata, Metadata, MetadataIndex, STATE_DICT_TYPE, TensorStorageMetadata
+from torch.distributed._shard.checkpoint.planner_helpers import _create_sharded_read_items, _create_read_items
+from torch.distributed._shard.checkpoint.utils import find_state_dict_object, find_tensor_shard
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.sharded_tensor.metadata import ShardedTensorMetadata, TensorProperties
+from torch.distributed._shard.sharded_tensor.shard import Shard
+from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
+from torch.distributed.remote_device import _remote_device
+
+from spmd import DTensor as DT
+from torch.distributed._shard.checkpoint.default_planner import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner
+)
+from torch.distributed._shard.api import _shard_tensor
+
+from .nested_dict import unflatten_state_dict
+from .utils import (element_wise_add, element_wise_sub)
+
+import torch
+
+
+def gen_rank_device(global_rank):
+    if torch.cuda.is_available():
+        return f"cuda:{global_rank % torch.cuda.device_count()}"
+    return "cpu"
+
+def create_colwise_spec(pg=None):
+    if pg is None:
+        placements = [
+            f"rank:{idx}/{gen_rank_device(idx)}"
+            for idx in range(dist.get_world_size())
+        ]
+    else:
+        placements = [
+            f"rank:{idx}/{gen_rank_device(dist.distributed_c10d.get_global_rank(pg, idx))}"
+            for idx in range(pg.size())
+        ]
+    return ChunkShardingSpec(
+        dim=0,
+        placements=placements,
+    )
+
+def is_nested_tensor(val: Any) -> bool:
+    if isinstance(val, ShardedTensor):
+        if len(val.local_shards()) == 0:
+            return False
+        if isinstance(val.local_shards()[0].tensor, ShardedTensor):
+            return True
+        if isinstance(val.local_shards()[0].tensor, DT):
+            raise ValueError("Cannot handle DT nested insided ST")
+    # Safety valve for when this eventually happen
+    elif isinstance(val, DT) and isinstance(val._local_tensor, (DT, ShardedTensor)):
+        raise ValueError("Cannot handle nested DT")
+    return False
+
+def alloc_tensor(props: TensorProperties, size: torch.Size):
+    return torch.empty(
+        size=size,
+        dtype=props.dtype,
+        layout=props.layout,
+        requires_grad=props.requires_grad,
+        pin_memory=props.pin_memory,
+        device=torch.cuda.current_device()
+    )
+
+def get_state_dict_2d_layout(state_dict: STATE_DICT_TYPE) -> Tuple[Dict[str, Tuple[Sequence[int], Sequence[int]]], dist.ProcessGroup]:
+    """
+    We have to load the right TP slice of the optimizer state.
+    This is not easy since the per-tensor slicing can't be inferred from checkpoint metadata.
+    We take advantage of the model state_dict producing a sliced ST to figure out what we need to load.
+    This is pretty fragile and it might be easier for FSDP to compute this info for us.
+
+    Returns a dictionary where keys are the same of the state_dict and the value is a tuple of
+    (offset, size) for the current rank TP slice.
+
+    N.B. The state_dict *MUST* come from FSDP.sharded_state_dict.
+    """
+    specs = {}
+    dp_pg = None
+    for key, value in state_dict.items():
+        specs[key] = (None, value.size())
+        if is_nested_tensor(value):
+            assert len(value.local_shards()) == 1, "Cannot handle ST with multiple shards"
+            shard = value.local_shards()[0]
+            specs[key] = (shard.metadata.shard_offsets, shard.metadata.shard_sizes)
+            dp_pg = shard.tensor._process_group
+
+    return (specs, dp_pg, )
+
+# TODO does it make sense to move this to UberLoadPlanner?
+class ReaderWithOffset(DefaultLoadPlanner):
+    def __init__(self, fqn_to_offset) -> None:
+        super().__init__()
+        # str ->tuple(offset, size)
+        self.fqn_to_offset = fqn_to_offset
+    
+    def create_local_plan(self) -> LoadPlan:
+        requests = []
+        self.translation = {}
+        for fqn, obj in self.state_dict.items():
+            md = self.metadata.state_dict_metadata[fqn]
+            if not isinstance(obj, ShardedTensor):
+                requests += _create_read_items(fqn, md, obj)
+                continue
+
+            if fqn not in self.fqn_to_offset:
+                requests += _create_read_items(fqn, md, obj)
+                continue
+            
+            offset = self.fqn_to_offset[fqn]
+
+            assert len(obj.local_shards()) == 1
+            original_shard = obj.local_shards()[0]
+            shard_md = copy.deepcopy(original_shard.metadata)
+            shard_md.shard_offsets = element_wise_add(shard_md.shard_offsets, offset)
+            local_shards = [Shard(original_shard.tensor, shard_md)]
+
+            reqs = _create_sharded_read_items(fqn, md, local_shards)
+            # The WriteItems will have a displaced MetadataIndex, fix it.
+            # BTW, we should change _create_sharded_read_items to have more ergnomic API
+            for wi in reqs:
+                original_offset = element_wise_sub(wi.dest_index.offset, offset)
+                original_index = dataclasses.replace(wi.dest_index, offset=torch.Size(original_offset))
+                self.translation[wi.dest_index] = original_index
+
+            requests += reqs
+        return LoadPlan(requests)
+
+    def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
+        return super().lookup_tensor(self.translation.get(index, index))
+
+
+def load_sharded_optimizer_state_dict(model_state_dict, optimizer_key, storage_reader):
+    """
+    This will load a state_dict to be used in conjuntion with FSDP sharded optimizer state.
+
+    # Save
+    model: torch.nn.Model
+    optim_params = model.parameters()
+    optim = torch.optim.SGD(optim_params, lr=0.01)
+
+    with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
+        state_dict = {
+            "optimizer": FSDP.sharded_optim_state_dict(model, optim, optim_params),
+            "model": model.state_dict()
+        }
+        dist_cp.save_state_dict(
+            state_dict=optim_state,
+            storage_writer=dist_cp.FileSystemWriter("checkpoint"),
+            planner=UberSavePlanner()
+        )
+
+    # Load
+    with FSDP.state_dict_type(model_tp, StateDictType.SHARDED_STATE_DICT):
+        model_state_dict = model_tp.state_dict()
+        checkpoint = {
+            "model" = model_state_dict
+        }
+        dist_cp.load_state_dict(
+            state_dict=checkpoint,
+            storage_reader=dist_cp.FileSystemReader(checkpoint_file),
+            planner=UberLoadPlanner()
+        )
+        model.load_state_dict(checkpoint["model_state"])
+
+        optim_state = load_sharded_optimizer_state_dict(
+            model_state_dict,
+            optimizer_key="optimizer",
+            storage_reader=dist_cp.FileSystemReader("checkpoint"), 
+        )
+
+        flattened_osd = FSDP.flatten_sharded_optim_state_dict(
+            optim_state["optimizer"], model, optim_input
+        )
+
+        optim.load_state_dict(flattened_osd)
+    """
+    metadata = storage_reader.read_metadata()
+
+    layout_specs, dp_pg = get_state_dict_2d_layout(model_state_dict)
+
+    if dp_pg is None:
+        sharding_spec = ChunkShardingSpec(
+            dim=0,
+            placements=[f"rank:{i}/cuda:{i}" for i in range(dist.get_world_size())]
+        )
+    else:
+        sharding_spec = create_colwise_spec(dp_pg)
+    # Create a state_dict for optimizer state
+    state_dict = {}
+    """
+    If we assume that the whole optimizer state is put under a single key, say 'optim', we'd be able to encode this as follows:
+
+    get all keys with path prefix: ('optim')
+
+    For all tensor types we use the 3rd component as the key into spec_key, IE:
+    ('optim', 'state', 'net1.bias', 'exp_avg') -> 'net1.bias'
+
+    """
+    fqn_to_offset = {}
+    for key, value in metadata.state_dict_metadata.items():
+        key_path = metadata.planner_data[key]
+        if key_path[0] != optimizer_key:
+            continue
+
+        if isinstance(value, BytesStorageMetadata):
+            state_dict[key] = "<bytes_io>"
+            continue
+        value: TensorStorageMetadata
+        if value.size.numel() == 1:
+            state_dict[key] = alloc_tensor(value.properties, value.size)
+        elif dp_pg is not None:
+            state_dict[key] = _shard_tensor(alloc_tensor(value.properties, value.size), sharding_spec)
+        else:
+            spec_key = key_path[2]
+            alloc_size = layout_specs.get(spec_key, (None, value.size))[1]
+
+            st_md = sharding_spec.build_metadata(alloc_size, value.properties)
+            local_shards = []
+            current_rank = dist.get_rank(dp_pg)
+            for shard_md in st_md.shards_metadata:
+                if shard_md.placement.rank() != current_rank:
+                    continue
+                local_shards.append(
+                    Shard(
+                        tensor=alloc_tensor(value.properties, shard_md.shard_sizes),
+                        metadata=shard_md,
+                    )
+                )
+
+            st = ShardedTensor._init_from_local_shards_and_global_metadata(
+                local_shards, st_md, process_group=dp_pg
+            )
+
+            if spec_key in layout_specs and layout_specs[spec_key][0] is not None:
+                fqn_to_offset[key] = layout_specs[spec_key][0]
+
+            state_dict[key] = st
+
+    # Whether we unflatten before or after doesn't matter
+    dist_cp.load_state_dict(
+        state_dict=state_dict,
+        storage_reader=storage_reader,
+        planner=ReaderWithOffset(fqn_to_offset) if dp_pg is not None else None
+    )
+
+    state_dict = unflatten_state_dict(state_dict, metadata.planner_data)
+
+    return state_dict
+
+# TODO add non-FSDP optimizer support
+

--- a/spmd/checkpoint/optimizer.py
+++ b/spmd/checkpoint/optimizer.py
@@ -1,83 +1,101 @@
 import copy
 import dataclasses
-from functools import reduce, partial
-import io
-import math
-from pickle import FALSE
-from typing import Dict,Any, List, Sequence, Tuple
-from torch.distributed._shard.checkpoint.planner import LoadPlan, ReadItem, SavePlan
-from torch.distributed._shard.sharded_tensor import shard
+from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
+from torch.distributed import distributed_c10d
+from torch.distributed._shard.checkpoint.planner import LoadPlan
 
-from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+import torch
 import torch.distributed as dist
-import torch.distributed._shard.checkpoint as dist_cp
-from torch.distributed._shard.checkpoint.metadata import BytesStorageMetadata, ChunkStorageMetadata, Metadata, MetadataIndex, STATE_DICT_TYPE, TensorStorageMetadata
-from torch.distributed._shard.checkpoint.planner_helpers import _create_sharded_read_items, _create_read_items
-from torch.distributed._shard.checkpoint.utils import find_state_dict_object, find_tensor_shard
-from torch.distributed._shard.metadata import ShardMetadata
-from torch.distributed._shard.sharded_tensor.metadata import ShardedTensorMetadata, TensorProperties
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
 from torch.distributed._shard.sharded_tensor.shard import Shard
-from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
+from torch.distributed._shard.sharding_spec.chunk_sharding_spec import (
+    ChunkShardingSpec,
+)
+
+import torch.distributed._shard.checkpoint as dist_cp
+from torch.distributed._shard.checkpoint.metadata import (
+    BytesStorageMetadata,
+    Metadata,
+    MetadataIndex,
+    STATE_DICT_TYPE,
+    TensorStorageMetadata,
+)
+from torch.distributed._shard.checkpoint.planner_helpers import (
+    _create_sharded_read_items,
+    _create_read_items,
+)
 from torch.distributed.remote_device import _remote_device
 
 from spmd import DTensor as DT
 from torch.distributed._shard.checkpoint.default_planner import (
     DefaultLoadPlanner,
-    DefaultSavePlanner
 )
 from torch.distributed._shard.api import _shard_tensor
 
 from .nested_dict import unflatten_state_dict
-from .utils import (element_wise_add, element_wise_sub)
+from .utils import _element_wise_add, _element_wise_sub
 
-import torch
+STATE_DICT_2D_LAYOUT = Dict[str, Tuple[Optional[Sequence[int]], Sequence[int]]]
 
 
-def gen_rank_device(global_rank):
+def _gen_rank_device(global_rank: int) -> str:
     if torch.cuda.is_available():
         return f"cuda:{global_rank % torch.cuda.device_count()}"
     return "cpu"
 
-def create_colwise_spec(pg=None):
+
+def _create_colwise_spec(
+    pg: Optional[dist.ProcessGroup] = None,
+) -> ChunkShardingSpec:
     if pg is None:
         placements = [
-            f"rank:{idx}/{gen_rank_device(idx)}"
+            f"rank:{idx}/{_gen_rank_device(idx)}"
             for idx in range(dist.get_world_size())
         ]
     else:
         placements = [
-            f"rank:{idx}/{gen_rank_device(dist.distributed_c10d.get_global_rank(pg, idx))}"
-            for idx in range(pg.size())
+            f"rank:{idx}/{_gen_rank_device(dist.get_global_rank(cast(dist.distributed_c10d.ProcessGroup, pg), idx))}"
+            for idx in range(pg.size())  # type: ignore[16]
         ]
-    return ChunkShardingSpec(
+    return ChunkShardingSpec(  # pyre-ignore[28]
         dim=0,
-        placements=placements,
+        placements=cast(List[Union[_remote_device, str]], placements),
     )
 
-def is_nested_tensor(val: Any) -> bool:
-    if isinstance(val, ShardedTensor):
+
+def _is_nested_tensor(val: torch.Tensor) -> bool:
+    if type(val) is ShardedTensor:
         if len(val.local_shards()) == 0:
             return False
-        if isinstance(val.local_shards()[0].tensor, ShardedTensor):
+        if type(val.local_shards()[0].tensor) is ShardedTensor:
             return True
-        if isinstance(val.local_shards()[0].tensor, DT):
-            raise ValueError("Cannot handle DT nested insided ST")
-    # Safety valve for when this eventually happen
-    elif isinstance(val, DT) and isinstance(val._local_tensor, (DT, ShardedTensor)):
-        raise ValueError("Cannot handle nested DT")
+        if type(val.local_shards()[0].tensor) is DT:
+            raise ValueError(
+                "Cannot handle DTensor nested insided ShardedTensor"
+            )
+    elif type(val) is DT and (
+        type(val._local_tensor) is DT
+        or type(val._local_tensor) is ShardedTensor
+    ):
+        raise ValueError("Cannot handle nested DTensor")
     return False
 
-def alloc_tensor(props: TensorProperties, size: torch.Size):
+
+def _alloc_tensor(props: TensorProperties, size: Sequence[int]) -> torch.Tensor:
     return torch.empty(
         size=size,
         dtype=props.dtype,
         layout=props.layout,
         requires_grad=props.requires_grad,
         pin_memory=props.pin_memory,
-        device=torch.cuda.current_device()
+        device=cast(torch.device, torch.cuda.current_device()),
     )
 
-def get_state_dict_2d_layout(state_dict: STATE_DICT_TYPE) -> Tuple[Dict[str, Tuple[Sequence[int], Sequence[int]]], dist.ProcessGroup]:
+
+def _get_state_dict_2d_layout(
+    state_dict: STATE_DICT_TYPE,
+) -> Tuple[STATE_DICT_2D_LAYOUT, Optional[dist.ProcessGroup]]:
     """
     We have to load the right TP slice of the optimizer state.
     This is not easy since the per-tensor slicing can't be inferred from checkpoint metadata.
@@ -89,25 +107,40 @@ def get_state_dict_2d_layout(state_dict: STATE_DICT_TYPE) -> Tuple[Dict[str, Tup
 
     N.B. The state_dict *MUST* come from FSDP.sharded_state_dict.
     """
-    specs = {}
-    dp_pg = None
+    specs: STATE_DICT_2D_LAYOUT = {}
+    dp_pg: Optional[dist.ProcessGroup] = None
     for key, value in state_dict.items():
         specs[key] = (None, value.size())
-        if is_nested_tensor(value):
-            assert len(value.local_shards()) == 1, "Cannot handle ST with multiple shards"
+        if _is_nested_tensor(value):
+            assert (
+                len(value.local_shards()) == 1
+            ), "Cannot handle ST with multiple shards"
+            assert isinstance(ShardedTensor, value)
             shard = value.local_shards()[0]
-            specs[key] = (shard.metadata.shard_offsets, shard.metadata.shard_sizes)
+            specs[key] = (
+                shard.metadata.shard_offsets,
+                shard.metadata.shard_sizes,
+            )
             dp_pg = shard.tensor._process_group
 
-    return (specs, dp_pg, )
+    return (
+        specs,
+        dp_pg,
+    )
 
-# TODO does it make sense to move this to UberLoadPlanner?
-class ReaderWithOffset(DefaultLoadPlanner):
-    def __init__(self, fqn_to_offset) -> None:
+
+class _ReaderWithOffset(DefaultLoadPlanner):
+    translation: Dict[MetadataIndex, MetadataIndex]
+    state_dict: STATE_DICT_TYPE
+    metadata: Metadata
+
+    def __init__(self, fqn_to_offset: Dict[str, Sequence[int]]) -> None:
         super().__init__()
-        # str ->tuple(offset, size)
         self.fqn_to_offset = fqn_to_offset
-    
+        self.metadata = Metadata({})
+        self.state_dict = {}
+        self.translation = {}
+
     def create_local_plan(self) -> LoadPlan:
         requests = []
         self.translation = {}
@@ -120,21 +153,30 @@ class ReaderWithOffset(DefaultLoadPlanner):
             if fqn not in self.fqn_to_offset:
                 requests += _create_read_items(fqn, md, obj)
                 continue
-            
+
             offset = self.fqn_to_offset[fqn]
 
             assert len(obj.local_shards()) == 1
             original_shard = obj.local_shards()[0]
             shard_md = copy.deepcopy(original_shard.metadata)
-            shard_md.shard_offsets = element_wise_add(shard_md.shard_offsets, offset)
+            shard_md.shard_offsets = _element_wise_add(
+                shard_md.shard_offsets, offset
+            )
             local_shards = [Shard(original_shard.tensor, shard_md)]
 
-            reqs = _create_sharded_read_items(fqn, md, local_shards)
+            reqs = _create_sharded_read_items(
+                fqn, cast(TensorStorageMetadata, md), local_shards
+            )
             # The WriteItems will have a displaced MetadataIndex, fix it.
             # BTW, we should change _create_sharded_read_items to have more ergnomic API
             for wi in reqs:
-                original_offset = element_wise_sub(wi.dest_index.offset, offset)
-                original_index = dataclasses.replace(wi.dest_index, offset=torch.Size(original_offset))
+                assert wi.dest_index.offset is not None
+                original_offset = _element_wise_sub(
+                    wi.dest_index.offset, offset
+                )
+                original_index = dataclasses.replace(
+                    wi.dest_index, offset=torch.Size(original_offset)
+                )
                 self.translation[wi.dest_index] = original_index
 
             requests += reqs
@@ -144,74 +186,77 @@ class ReaderWithOffset(DefaultLoadPlanner):
         return super().lookup_tensor(self.translation.get(index, index))
 
 
-def load_sharded_optimizer_state_dict(model_state_dict, optimizer_key, storage_reader):
+def load_sharded_optimizer_state_dict(
+    model_state_dict: STATE_DICT_TYPE,
+    optimizer_key: str,
+    storage_reader: dist_cp.StorageReader,
+) -> STATE_DICT_TYPE:
     """
-    This will load a state_dict to be used in conjuntion with FSDP sharded optimizer state.
+    Loads a state_dict to be used in conjuntion with FSDP sharded optimizer state.
 
-    # Save
-    model: torch.nn.Model
-    optim_params = model.parameters()
-    optim = torch.optim.SGD(optim_params, lr=0.01)
+    This is the current recommended way to checkpoint is FSDP
 
-    with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
-        state_dict = {
-            "optimizer": FSDP.sharded_optim_state_dict(model, optim, optim_params),
-            "model": model.state_dict()
-        }
-        dist_cp.save_state_dict(
-            state_dict=optim_state,
-            storage_writer=dist_cp.FileSystemWriter("checkpoint"),
-            planner=UberSavePlanner()
-        )
+    >>> import torch.distributed._shard.checkpoint as dist_cp
+    >>> import spmd.checkpoint as sp_cp
+    >>> # Save
+    >>> model: torch.nn.Model
+    >>> optim_params = model.parameters()
+    >>> optim = torch.optim.SGD(optim_params, lr=0.01)
+    >>>
+    >>> with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
+    >>>     state_dict = {
+    >>>         "optimizer": FSDP.sharded_optim_state_dict(model, optim, optim_params),
+    >>>         "model": model.state_dict()
+    >>>     }
+    >>>     dist_cp.save_state_dict(
+    >>>         state_dict=optim_state,
+    >>>         storage_writer=dist_cp.FileSystemWriter("checkpoint"),
+    >>>         planner=sp_cp.AdvLoadPlanner()
+    >>>     )
+    >>>
+    >>> # Load
+    >>> with FSDP.state_dict_type(model_tp, StateDictType.SHARDED_STATE_DICT):
+    >>>     model_state_dict = model_tp.state_dict()
+    >>>     checkpoint = {
+    >>>         "model" = model_state_dict
+    >>>     }
+    >>>     dist_cp.load_state_dict(
+    >>>         state_dict=checkpoint,
+    >>>         storage_reader=dist_cp.FileSystemReader(checkpoint_file),
+    >>>         planner=sp_cp.AdvLoadPlanner()
+    >>>     )
+    >>>     model.load_state_dict(checkpoint["model_state"])
+    >>>
+    >>>     optim_state = sp_cp.load_sharded_optimizer_state_dict(
+    >>>         model_state_dict,
+    >>>         optimizer_key="optimizer",
+    >>>         storage_reader=dist_cp.FileSystemReader("checkpoint"),
+    >>>    )
+    >>>
+    >>>    flattened_osd = FSDP.flatten_sharded_optim_state_dict(
+    >>>        optim_state["optimizer"], model, optim_input
+    >>>    )
+    >>>
+    >>>    optim.load_state_dict(flattened_osd)
 
-    # Load
-    with FSDP.state_dict_type(model_tp, StateDictType.SHARDED_STATE_DICT):
-        model_state_dict = model_tp.state_dict()
-        checkpoint = {
-            "model" = model_state_dict
-        }
-        dist_cp.load_state_dict(
-            state_dict=checkpoint,
-            storage_reader=dist_cp.FileSystemReader(checkpoint_file),
-            planner=UberLoadPlanner()
-        )
-        model.load_state_dict(checkpoint["model_state"])
-
-        optim_state = load_sharded_optimizer_state_dict(
-            model_state_dict,
-            optimizer_key="optimizer",
-            storage_reader=dist_cp.FileSystemReader("checkpoint"), 
-        )
-
-        flattened_osd = FSDP.flatten_sharded_optim_state_dict(
-            optim_state["optimizer"], model, optim_input
-        )
-
-        optim.load_state_dict(flattened_osd)
     """
     metadata = storage_reader.read_metadata()
 
-    layout_specs, dp_pg = get_state_dict_2d_layout(model_state_dict)
+    layout_specs, dp_pg = _get_state_dict_2d_layout(model_state_dict)
 
     if dp_pg is None:
-        sharding_spec = ChunkShardingSpec(
+        sharding_spec = ChunkShardingSpec(  # pyre-ignore[28]
             dim=0,
-            placements=[f"rank:{i}/cuda:{i}" for i in range(dist.get_world_size())]
+            placements=[
+                f"rank:{i}/cuda:{i}" for i in range(dist.get_world_size())
+            ],
         )
     else:
-        sharding_spec = create_colwise_spec(dp_pg)
+        sharding_spec = _create_colwise_spec(dp_pg)
     # Create a state_dict for optimizer state
-    state_dict = {}
-    """
-    If we assume that the whole optimizer state is put under a single key, say 'optim', we'd be able to encode this as follows:
+    state_dict: STATE_DICT_TYPE = {}
 
-    get all keys with path prefix: ('optim')
-
-    For all tensor types we use the 3rd component as the key into spec_key, IE:
-    ('optim', 'state', 'net1.bias', 'exp_avg') -> 'net1.bias'
-
-    """
-    fqn_to_offset = {}
+    fqn_to_offset: Dict[str, Sequence[int]] = {}
     for key, value in metadata.state_dict_metadata.items():
         key_path = metadata.planner_data[key]
         if key_path[0] != optimizer_key:
@@ -220,24 +265,35 @@ def load_sharded_optimizer_state_dict(model_state_dict, optimizer_key, storage_r
         if isinstance(value, BytesStorageMetadata):
             state_dict[key] = "<bytes_io>"
             continue
-        value: TensorStorageMetadata
+        # value: TensorStorageMetadata
         if value.size.numel() == 1:
-            state_dict[key] = alloc_tensor(value.properties, value.size)
-        elif dp_pg is not None:
-            state_dict[key] = _shard_tensor(alloc_tensor(value.properties, value.size), sharding_spec)
+            state_dict[key] = _alloc_tensor(value.properties, value.size)
+        elif dp_pg is None:
+            state_dict[key] = _shard_tensor(
+                _alloc_tensor(value.properties, value.size), sharding_spec
+            )
         else:
             spec_key = key_path[2]
             alloc_size = layout_specs.get(spec_key, (None, value.size))[1]
 
-            st_md = sharding_spec.build_metadata(alloc_size, value.properties)
+            st_md = sharding_spec.build_metadata(
+                torch.Size(alloc_size), value.properties
+            )
             local_shards = []
-            current_rank = dist.get_rank(dp_pg)
+            current_rank = dist.get_rank(
+                cast(dist.distributed_c10d.ProcessGroup, dp_pg)
+            )
             for shard_md in st_md.shards_metadata:
-                if shard_md.placement.rank() != current_rank:
+                if (
+                    cast(_remote_device, shard_md.placement).rank()
+                    != current_rank
+                ):
                     continue
                 local_shards.append(
                     Shard(
-                        tensor=alloc_tensor(value.properties, shard_md.shard_sizes),
+                        tensor=_alloc_tensor(
+                            value.properties, shard_md.shard_sizes
+                        ),
                         metadata=shard_md,
                     )
                 )
@@ -246,8 +302,13 @@ def load_sharded_optimizer_state_dict(model_state_dict, optimizer_key, storage_r
                 local_shards, st_md, process_group=dp_pg
             )
 
-            if spec_key in layout_specs and layout_specs[spec_key][0] is not None:
-                fqn_to_offset[key] = layout_specs[spec_key][0]
+            if (
+                spec_key in layout_specs
+                and layout_specs[spec_key][0] is not None
+            ):
+                fqn_to_offset[key] = cast(
+                    Sequence[int], layout_specs[spec_key][0]
+                )
 
             state_dict[key] = st
 
@@ -255,12 +316,10 @@ def load_sharded_optimizer_state_dict(model_state_dict, optimizer_key, storage_r
     dist_cp.load_state_dict(
         state_dict=state_dict,
         storage_reader=storage_reader,
-        planner=ReaderWithOffset(fqn_to_offset) if dp_pg is not None else None
+        # FIXME the type of planner is wrong in load_state_dict
+        planner=_ReaderWithOffset(fqn_to_offset) if dp_pg is not None else None,  # type: ignore[index]
     )
 
     state_dict = unflatten_state_dict(state_dict, metadata.planner_data)
 
     return state_dict
-
-# TODO add non-FSDP optimizer support
-

--- a/spmd/checkpoint/planners.py
+++ b/spmd/checkpoint/planners.py
@@ -1,0 +1,165 @@
+import copy
+import dataclasses
+from functools import reduce, partial
+import io
+import math
+from pickle import FALSE
+from typing import Dict,Any, List, Sequence, Tuple
+from torch.distributed._shard.checkpoint.planner import LoadPlan, ReadItem, SavePlan
+from torch.distributed._shard.sharded_tensor import shard
+
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+import torch.distributed as dist
+import torch.distributed._shard.checkpoint as dist_cp
+from torch.distributed._shard.checkpoint.metadata import BytesStorageMetadata, ChunkStorageMetadata, Metadata, MetadataIndex, STATE_DICT_TYPE, TensorStorageMetadata
+from torch.distributed._shard.checkpoint.planner_helpers import _create_sharded_read_items, _create_read_items
+from torch.distributed._shard.checkpoint.utils import find_state_dict_object, find_tensor_shard
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.sharded_tensor.metadata import ShardedTensorMetadata, TensorProperties
+from torch.distributed._shard.sharded_tensor.shard import Shard
+from torch.distributed._shard.sharding_spec.chunk_sharding_spec import ChunkShardingSpec
+from torch.distributed.remote_device import _remote_device
+
+from spmd import DTensor as DT
+from torch.distributed._shard.checkpoint.default_planner import (
+    DefaultLoadPlanner,
+    DefaultSavePlanner
+)
+from torch.distributed._shard.api import _shard_tensor
+import logging
+
+from .nested_dict import (
+    flatten_state_dict,
+    set_element,
+    get_element,
+)
+logger = logging.getLogger(__file__)
+
+def check_box_overlap(box0, box1):
+    """
+    Checks if two boxes overlap. Tuples are (offset, lengths)
+    """
+
+    # For each dim of each shard, check if one shard resides on the other
+    # end of second shard with respect to that dim. As an example for a 2D
+    # shard, we would check if one shard is above or on the left of the
+    # other shard.
+    ndims = len(box0.offsets)
+    for i in range(ndims):
+        if box0.offsets[i] >= box1.offsets[i] + box1.sizes[i]:
+            return False
+        if box1.offsets[i] >= box0.offsets[i] + box0.sizes[i]:
+            return False
+
+    return True
+
+def check_box_bounds(outer_box_size, inner_box):
+    for i in range(len(outer_box_size)):
+        if inner_box.offsets[i] < 0:
+            return False
+        if inner_box.sizes[i] < 0:
+            return False
+        if inner_box.offsets[i] + inner_box.sizes[i] > outer_box_size[i]:
+            return False
+
+    return True
+
+def validate_global_plan(global_plan: List[SavePlan], metadata: Metadata) -> bool:
+    all_good = True
+    for key, value in metadata.state_dict_metadata.items():
+        if isinstance(value, BytesStorageMetadata):
+            continue
+        if len(value.size) == 0:
+            continue
+        #check for overlap
+        chunks_volume = 0
+        for chunk_idx, chunk0 in enumerate(value.chunks):
+            if not check_box_bounds(value.size, chunk0):
+                logger.warning(f"key:{key} has out of bounds chunk: tensor-size:{value.size} chunk: {chunk0}")
+                all_good = False
+            chunks_volume += math.prod(chunk0.sizes)
+
+            for chunk1 in value.chunks[chunk_idx + 1:]:
+                if check_box_overlap(chunk0, chunk1):
+                    logger.warning(f"key:{key} has overlapping chunks: {chunk0} {chunk1}")
+                    all_good = False
+
+        tensor_volume = math.prod(value.size)
+        if chunks_volume != tensor_volume:
+            logger.warning(f"key:{key} invalid fill tensor-volume: {tensor_volume} chunks-volume: {chunks_volume}")
+            all_good = False
+
+    return all_good
+
+# TODO find a better name for this class
+class UberSavePlanner(DefaultSavePlanner):
+    def __init__(
+        self,
+        flatten_state_dict=True,
+        flatten_sharded_tensors=True,
+        dedup_replicated_tensors=True
+    ):
+        self.flatten_state_dict = flatten_state_dict
+        self.flatten_sharded_tensors = flatten_sharded_tensors
+        self.dedup_replicated_tensors = dedup_replicated_tensors
+
+    def init(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
+        if self.flatten_state_dict:
+            state_dict, self.mappings = flatten_state_dict(state_dict)
+        if self.flatten_sharded_tensors:
+            state_dict = flatten_sharded_tensors(state_dict)
+        return super().init(state_dict, is_coordinator)
+
+    def create_local_plan(self) -> SavePlan:
+        plan = super().create_local_plan()
+        if self.flatten_state_dict:
+            plan = dataclasses.replace(plan, planner_data=self.mappings)
+        return plan
+
+    def create_global_plan(self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+        if self.dedup_replicated_tensors:
+            all_plans = dedup_tensors(all_plans)
+
+        global_plan, metadata = super().create_global_plan(all_plans)
+
+        if self.flatten_state_dict:
+            merged_mappings = reduce(lambda x, y: x | y, (p.planner_data for p in global_plan))
+            metadata = dataclasses.replace(metadata, planner_data=merged_mappings)
+
+        if not validate_global_plan(global_plan, metadata):
+            raise ValueError("Failed to validate global plan")
+
+        return global_plan, metadata
+
+# TODO find a better name for this class
+class UberLoadPlanner(DefaultLoadPlanner):
+    def __init__(
+        self,
+        flatten_state_dict=True,
+        flatten_sharded_tensors=True,
+    ):
+        self.flatten_state_dict = flatten_state_dict
+        self.flatten_sharded_tensors = flatten_sharded_tensors
+
+    def init(self, state_dict: STATE_DICT_TYPE, metadata: Metadata, is_coordinator: bool) -> None:
+        if self.flatten_sharded_tensors:
+            state_dict = flatten_sharded_tensors(state_dict)
+
+        self.original_state_dict = state_dict        
+        if self.flatten_state_dict:
+            state_dict, self.mappings = flatten_state_dict(state_dict)
+            # Note that we don't need the checkpoint mappings as we assume
+            # that they are compatible with the one we just computed
+
+        return super().init(state_dict, metadata, is_coordinator)
+
+    def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+        set_element(
+            self.original_state_dict,
+            self.mappings[read_item.dest_index.fqn],
+            torch.load(value)
+        )
+
+    def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
+        obj = get_element(self.original_state_dict, self.mappings[index.fqn])
+        return find_tensor_shard(obj, index)

--- a/spmd/checkpoint/traverse.py
+++ b/spmd/checkpoint/traverse.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import torch
+
+from typing import (
+    Callable,
+    Collection,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+from torch.distributed._shard.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from spmd import DTensor as DT
+
+PATH_ITEM = Union[str, int]
+OBJ_PATH = Tuple[PATH_ITEM, ...]
+T = TypeVar("T")
+
+STATE_DICT_ITEM = object
+CONTAINER_TYPE = MutableMapping[PATH_ITEM, STATE_DICT_ITEM]
+
+
+def _keep_visiting_tensors(value: STATE_DICT_ITEM) -> bool:
+    return isinstance(value, torch.Tensor)
+
+
+def traverse_state_dict(
+    state_dict: STATE_DICT_TYPE,
+    visitor: Callable[[OBJ_PATH, STATE_DICT_ITEM], None],
+    keep_traversing: Callable[[STATE_DICT_ITEM], bool] = _keep_visiting_tensors,
+) -> None:
+    """
+    Invoke ``visitor`` for each value recursively in ``state_dict``.
+
+    Traversal is short-circuited when if finds a collection for which ``keep_visiting_tensors`` evaluates
+    to false for all elements.
+
+    By default, all collections with at least one ``torch.Tensor`` element are traversed.
+
+    Visitor takes a path argument that is a tuple of the keys used to reach it.
+    """
+    # a value is terminal if it has no other containers values inside it
+    def _is_terminal(value: STATE_DICT_ITEM) -> bool:
+        values: Collection[STATE_DICT_ITEM]
+        if isinstance(value, Mapping):
+            values = value.values()
+        elif isinstance(value, list):
+            values = value
+        else:
+            return True
+
+        for entry in values:
+            if isinstance(
+                entry,
+                (
+                    Mapping,
+                    list,
+                ),
+            ) and not _is_terminal(entry):
+                return False
+            if keep_traversing is not None and keep_traversing(entry):
+                return False
+        return True
+
+    def _traverse_obj(path: OBJ_PATH, value: STATE_DICT_ITEM) -> None:
+        if _is_terminal(value):
+            visitor(path, value)
+        elif isinstance(value, Mapping):
+            for k, v in value.items():
+                _traverse_obj(path + (str(k),), v)
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                _traverse_obj(path + (i,), v)
+
+    for key, value in state_dict.items():
+        _traverse_obj((str(key),), value)
+
+
+def set_element(
+    root_dict: STATE_DICT_TYPE, path: OBJ_PATH, value: STATE_DICT_ITEM
+) -> None:
+    """
+    Set ``value`` in ``root_dict`` along the ``path`` object path.
+    """
+    cur_container = cast(CONTAINER_TYPE, root_dict)
+
+    def extend_list(lst: List[STATE_DICT_ITEM], idx: int) -> None:
+        while len(lst) <= idx:
+            lst.append(None)
+
+    for i in range(1, len(path)):
+        prev_key = path[i - 1]
+        key = path[i]
+        def_val = cast(STATE_DICT_ITEM, {} if type(key) == str else [])
+
+        if isinstance(cur_container, Mapping):
+            cur_container = cast(
+                CONTAINER_TYPE, cur_container.setdefault(prev_key, def_val)
+            )
+        else:
+            extend_list(cur_container, prev_key)
+            if cur_container[prev_key] is None:
+                cur_container[prev_key] = def_val
+            cur_container = cur_container[prev_key]
+
+    key = path[-1]
+    if type(key) == int:
+        extend_list(cast(List[STATE_DICT_ITEM], cur_container), key)
+
+    cur_container[key] = value
+
+
+def get_element(
+    root_dict: STATE_DICT_TYPE,
+    path: OBJ_PATH,
+    default_value: Optional[T] = None,
+) -> Optional[T]:
+    """
+    Retrieve the value at ``path``from ``root_dict``, returning ``default_value`` if not found.
+    """
+    cur_value = cast(CONTAINER_TYPE, root_dict)
+    for part in path:
+        if type(part) is int:
+            if not isinstance(cur_value, list) or len(cur_value) < part:
+                return default_value
+        elif not isinstance(cur_value, Mapping) or part not in cur_value:
+            return default_value
+
+        cur_value = cast(CONTAINER_TYPE, cur_value[part])
+    return cast(Optional[T], cur_value)
+
+
+def _print_nested(
+    value: STATE_DICT_ITEM,
+    padding: str = "",
+    prefix: str = "",
+    print_fun: Callable[[str], None] = print,
+) -> None:
+    if type(value) is ShardedTensor:
+        print_fun(f"{padding}{prefix} ShardedTensor size {value.size()}")
+        for shard in value.local_shards():
+            _print_nested(
+                shard.tensor,
+                f"{padding}\t",
+                f"{shard.metadata.shard_offsets} ",
+                print_fun=print_fun,
+            )
+    elif type(value) is (DT):
+        print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
+        _print_nested(
+            value._local_tensor,
+            f"{padding}\t",
+            "(offset ???) ",
+            print_fun=print_fun,
+        )
+    elif isinstance(value, torch.Tensor):
+        print_fun(f"{padding}{prefix} Tensor size {value.size()}")
+    else:
+        print_fun(f"{padding}{prefix} Type {type(value)}")
+
+
+def print_tensor(
+    path: OBJ_PATH,
+    value: STATE_DICT_ITEM,
+    print_fun: Callable[[str], None] = print,
+) -> None:
+    """
+    Callback that can be used with travese_state_dict to print its content.
+
+    By default the content is printed using the builtin ``print`` but this can
+    be change by passing a different ``print_fun` callable.
+    """
+    _print_nested(value, prefix=str(path), print_fun=print_fun)

--- a/spmd/checkpoint/utils.py
+++ b/spmd/checkpoint/utils.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import torch
+
+from typing import Mapping, List
+from torch.distributed._shard.checkpoint.metadata import (
+    STATE_DICT_TYPE,
+)
+from torch.distributed._shard.sharded_tensor.api import ShardedTensor
+from spmd import  DTensor as DT
+
+def keep_visiting_tensors(value):
+    return isinstance(value, torch.Tensor)
+
+def traverse_state_dict(state_dict: STATE_DICT_TYPE, visitor, keep_traversing=keep_visiting_tensors):
+    """
+    Invoke ``visitor`` for each value recursively in ``state_dict``.
+
+    Traversal is shortcuted when if finds a collection for which `keep_visiting_tensors` evaluates
+    to false for all elements.
+
+    By default, all collections with at least one ``torch.Tensor`` element are traversed.
+
+    Visitor takes a path argument that is a tuple of the keys used to reach it.
+    """
+    # a value is terminal if it has no other containers values inside it
+    def _is_terminal(value):
+        values = None
+        if isinstance(value, Mapping):
+            values = value.values()
+        elif isinstance(value, list):
+            values = value
+        else:
+            return True
+
+        for entry in values:
+            if isinstance(entry, (Mapping, list)) and not _is_terminal(entry):
+                return False
+            if keep_traversing is not None and keep_traversing(entry):
+                return False
+        return True
+
+    def _traverse_obj(path, value):
+        if _is_terminal(value):
+            visitor(path, value)
+        elif isinstance(value, Mapping):
+            for k, v in value.items():
+                _traverse_obj(path + (str(k),), v)
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                _traverse_obj(path + (i,), v)
+
+    for key, value in state_dict.items():
+        _traverse_obj((str(key),), value)
+
+
+
+def set_element(root_dict, path, value):
+    cur_container = root_dict
+
+    for i in range(1, len(path)):
+        prev_key = path[i - 1]
+        key = path[i]
+        if type(key) == str:
+            cur_container = cur_container.setdefault(prev_key, {})
+        else:
+            cur_container = cur_container.setdefault(prev_key, [])
+
+    key = path[-1]
+    if type(key) == int:
+        while len(cur_container) <= key:
+            cur_container.append(None)
+    cur_container[key] = value
+
+
+def get_element(root_dict, path, default_value=None):
+    cur_value = root_dict
+    for part in path:
+        if part not in cur_value:
+            return default_value
+        cur_value = cur_value[part]
+    return cur_value
+
+
+def _print_nested(value, padding="", prefix="", print_fun=print):
+    if isinstance(value, ShardedTensor):
+        print_fun(f"{padding}{prefix} ShardedTensor size {value.size()}")
+        for shard in value.local_shards():
+            _print_nested(shard.tensor, f"{padding}\t", f"{shard.metadata.shard_offsets} ", print_fun=print_fun)
+    elif isinstance(value, DT):
+        print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
+        # for shard in value.local_shards():
+        _print_nested(value.local_tensor, f"{padding}\t", f"(offset ???) ", print_fun=print_fun)
+    else:
+        print_fun(f"{padding}{prefix} Tensor size {value.size()}")
+
+def print_tensor(path, value, print_fun=print):
+    _print_nested(path, value, print_fun=print_fun)
+
+
+def element_wise_add(a: List[int], b: List[int]) -> List[int]:
+    return [i_a + i_b for i_a, i_b in zip(a,b)]

--- a/spmd/checkpoint/utils.py
+++ b/spmd/checkpoint/utils.py
@@ -1,101 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import torch
 
-from typing import Mapping, List
-from torch.distributed._shard.checkpoint.metadata import (
-    STATE_DICT_TYPE,
-)
-from torch.distributed._shard.sharded_tensor.api import ShardedTensor
-from spmd import  DTensor as DT
-
-def keep_visiting_tensors(value):
-    return isinstance(value, torch.Tensor)
-
-def traverse_state_dict(state_dict: STATE_DICT_TYPE, visitor, keep_traversing=keep_visiting_tensors):
-    """
-    Invoke ``visitor`` for each value recursively in ``state_dict``.
-
-    Traversal is shortcuted when if finds a collection for which `keep_visiting_tensors` evaluates
-    to false for all elements.
-
-    By default, all collections with at least one ``torch.Tensor`` element are traversed.
-
-    Visitor takes a path argument that is a tuple of the keys used to reach it.
-    """
-    # a value is terminal if it has no other containers values inside it
-    def _is_terminal(value):
-        values = None
-        if isinstance(value, Mapping):
-            values = value.values()
-        elif isinstance(value, list):
-            values = value
-        else:
-            return True
-
-        for entry in values:
-            if isinstance(entry, (Mapping, list)) and not _is_terminal(entry):
-                return False
-            if keep_traversing is not None and keep_traversing(entry):
-                return False
-        return True
-
-    def _traverse_obj(path, value):
-        if _is_terminal(value):
-            visitor(path, value)
-        elif isinstance(value, Mapping):
-            for k, v in value.items():
-                _traverse_obj(path + (str(k),), v)
-        elif isinstance(value, list):
-            for i, v in enumerate(value):
-                _traverse_obj(path + (i,), v)
-
-    for key, value in state_dict.items():
-        _traverse_obj((str(key),), value)
+from typing import List, Sequence
 
 
-
-def set_element(root_dict, path, value):
-    cur_container = root_dict
-
-    for i in range(1, len(path)):
-        prev_key = path[i - 1]
-        key = path[i]
-        if type(key) == str:
-            cur_container = cur_container.setdefault(prev_key, {})
-        else:
-            cur_container = cur_container.setdefault(prev_key, [])
-
-    key = path[-1]
-    if type(key) == int:
-        while len(cur_container) <= key:
-            cur_container.append(None)
-    cur_container[key] = value
+def _element_wise_add(a: Sequence[int], b: Sequence[int]) -> List[int]:
+    return [i_a + i_b for i_a, i_b in zip(a, b)]
 
 
-def get_element(root_dict, path, default_value=None):
-    cur_value = root_dict
-    for part in path:
-        if part not in cur_value:
-            return default_value
-        cur_value = cur_value[part]
-    return cur_value
-
-
-def _print_nested(value, padding="", prefix="", print_fun=print):
-    if isinstance(value, ShardedTensor):
-        print_fun(f"{padding}{prefix} ShardedTensor size {value.size()}")
-        for shard in value.local_shards():
-            _print_nested(shard.tensor, f"{padding}\t", f"{shard.metadata.shard_offsets} ", print_fun=print_fun)
-    elif isinstance(value, DT):
-        print_fun(f"{padding}{prefix} DistributedTensor size {value.size()}")
-        # for shard in value.local_shards():
-        _print_nested(value.local_tensor, f"{padding}\t", f"(offset ???) ", print_fun=print_fun)
-    else:
-        print_fun(f"{padding}{prefix} Tensor size {value.size()}")
-
-def print_tensor(path, value, print_fun=print):
-    _print_nested(path, value, print_fun=print_fun)
-
-
-def element_wise_add(a: List[int], b: List[int]) -> List[int]:
-    return [i_a + i_b for i_a, i_b in zip(a,b)]
+def _element_wise_sub(a: Sequence[int], b: Sequence[int]) -> List[int]:
+    return [i_a - i_b for i_a, i_b in zip(a, b)]

--- a/spmd/tensor/parallel/fsdp.py
+++ b/spmd/tensor/parallel/fsdp.py
@@ -310,7 +310,7 @@ def _pre_load_state_dict(
         inner_tensor = cast(ShardedTensor, shards[0].tensor)
         shards = inner_tensor.local_shards()
 
-    return (tensor, [shards[0].tensor] if len(shards) > 0 else [])
+    return (tensor, shards if len(shards) > 0 else [])
 
 
 try:

--- a/test/spmd/checkpoint/test_dedup_tensors.py
+++ b/test/spmd/checkpoint/test_dedup_tensors.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import dataclasses
+import torch
+from torch.distributed._shard.checkpoint.planner import SavePlan, WriteItemType
+from torch.distributed._shard.checkpoint.planner_helpers import (
+    _create_write_item_for_tensor,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+import spmd.checkpoint.dedup_tensors as dt
+
+
+def create_plan(second_fqn) -> SavePlan:
+    # the first wi is for a duplicated shard (that covers the whole tensor)
+    wi1 = _create_write_item_for_tensor("tensor_0", torch.rand(4))
+    wi1 = dataclasses.replace(wi1, type=WriteItemType.SHARD)
+
+    # the second wi has different keys
+    wi2 = _create_write_item_for_tensor(second_fqn, torch.rand(10))
+
+    return SavePlan([wi1, wi2])
+
+
+class TestDedupTensor(TestCase):
+    def test_dedup_shards(self):
+        rank0 = create_plan("r0")
+        rank1 = create_plan("r1")
+
+        dedup_plans = dt.dedup_tensors([rank0, rank1])
+
+        self.assertEqual(2, len(dedup_plans[0].items))
+        self.assertEqual(1, len(dedup_plans[1].items))
+
+        self.assertIn(
+            "tensor_0", (item.index.fqn for item in dedup_plans[0].items)
+        )
+        self.assertIn("r0", (item.index.fqn for item in dedup_plans[0].items))
+
+        self.assertIn("r1", (item.index.fqn for item in dedup_plans[1].items))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/spmd/checkpoint/test_fsdp_optim_state.py
+++ b/test/spmd/checkpoint/test_fsdp_optim_state.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+# mypy: ignore-errors
+
+import torch
+
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
+import torch.distributed._shard.checkpoint as dist_cp
+import torch.distributed as dist
+
+
+import spmd.checkpoint.adv_planner as ap
+import spmd.checkpoint.optimizer as opt
+
+from spmd.testing.checkpoint_utils import with_temp_dir
+from spmd.testing.common_utils import (
+    TEST_GPU_NUM,
+    DistTensorTestBase,
+    with_comms,
+)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import run_tests
+
+
+class FsdpOptimStateCheckpoint(DistTensorTestBase):
+    @with_comms
+    @skip_if_lt_x_gpu(TEST_GPU_NUM)
+    @with_temp_dir
+    def test_distributed_tensor_planner(self) -> None:
+        CHECKPOINT_DIR = self.temp_dir
+
+        model = FSDP(torch.nn.Linear(8, 8, device="meta"))
+        optim = torch.optim.Adam(model.parameters(), lr=0.1)
+
+        model(torch.rand(8, 8, device=dist.get_rank())).sum().backward()
+        optim.step()
+
+        with FSDP.state_dict_type(model, StateDictType.SHARDED_STATE_DICT):
+            state_dict = {
+                "model": model.state_dict(),
+                "optim": FSDP.sharded_optim_state_dict(model, optim),
+            }
+
+            dist_cp.save_state_dict(
+                state_dict=state_dict,
+                storage_writer=dist_cp.FileSystemWriter(CHECKPOINT_DIR),
+                planner=ap.AdvSavePlanner(),
+            )
+
+        # now load the model and ensure the values are the same
+        model_2 = FSDP(torch.nn.Linear(8, 8, device="meta"))
+        optim_2 = torch.optim.Adam(model_2.parameters(), lr=0.1)
+
+        with FSDP.summon_full_params(model):
+            with FSDP.summon_full_params(model_2):
+                self.assertNotEqual(model.weight, model_2.weight)
+                self.assertNotEqual(model.bias, model_2.bias)
+
+        # Adam lazily creates its state
+        self.assertEqual(0, len(optim_2.state))
+
+        with FSDP.state_dict_type(model_2, StateDictType.SHARDED_STATE_DICT):
+            state_dict = {
+                "model": model_2.state_dict(),
+                # cannot load the optimizer together with the model
+            }
+
+            dist_cp.load_state_dict(
+                state_dict=state_dict,
+                storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
+                planner=ap.AdvLoadPlanner(),
+            )
+            model_2.load_state_dict(state_dict["model"])
+
+            optim_state = opt.load_sharded_optimizer_state_dict(
+                model_state_dict=state_dict["model"],
+                optimizer_key="optim",
+                storage_reader=dist_cp.FileSystemReader(CHECKPOINT_DIR),
+            )
+
+            flattened_osd = FSDP.flatten_sharded_optim_state_dict(
+                optim_state["optim"], model_2
+            )
+            optim_2.load_state_dict(flattened_osd)
+
+        with FSDP.summon_full_params(model):
+            with FSDP.summon_full_params(model_2):
+                self.assertEqual(model.weight, model_2.weight)
+                self.assertEqual(model.bias, model_2.bias)
+
+        def opt_at(opt, idx):
+            return list(iter(opt.state.values()))[idx]
+
+        # Adam lazily creates its state
+        self.assertEqual(
+            opt_at(optim, 0)["exp_avg"], opt_at(optim_2, 0)["exp_avg"]
+        )
+        self.assertEqual(
+            opt_at(optim, 0)["exp_avg_sq"], opt_at(optim_2, 0)["exp_avg_sq"]
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/spmd/checkpoint/test_nested_dict.py
+++ b/test/spmd/checkpoint/test_nested_dict.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+import spmd.checkpoint.nested_dict as nd
+
+
+class TestFlattening(TestCase):
+    def test_flattening_round_trip(self) -> None:
+        state_dict = {
+            "key0": 1,
+            "key1": [1, 2],
+            "key2": {1: 2, 2: 3},
+            "key3": torch.tensor([1]),
+            "key4": [[torch.tensor(2), "x"], [1, 2, 3], {"key6": [44]}],
+        }
+
+        flatten_dict, mapping = nd.flatten_state_dict(state_dict)
+        restored = nd.unflatten_state_dict(flatten_dict, mapping)
+
+        self.assertEqual(state_dict, restored)
+
+    def test_mapping(self) -> None:
+        state_dict = {
+            "k0": [1],
+            "k2": [torch.tensor([1]), 99, [{"k3": torch.tensor(1)}]],
+            "k3": ["x", 99, [{"k3": "y"}]],
+        }
+
+        flatten_dict, mapping = nd.flatten_state_dict(state_dict)
+        self.assertIn(("k0",), mapping.values())
+        self.assertIn(
+            (
+                "k2",
+                0,
+            ),
+            mapping.values(),
+        )
+        self.assertIn(
+            (
+                "k2",
+                1,
+            ),
+            mapping.values(),
+        )
+        self.assertIn(("k2", 2, 0, "k3"), mapping.values())
+        self.assertIn(("k3",), mapping.values())
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/spmd/checkpoint/test_traverse.py
+++ b/test/spmd/checkpoint/test_traverse.py
@@ -1,0 +1,348 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+
+
+from collections import OrderedDict
+import torch
+from torch.distributed._shard.checkpoint.metadata import STATE_DICT_TYPE
+from torch.testing._internal.common_utils import run_tests, TestCase
+import spmd.checkpoint.traverse as tv
+
+
+class TestTraverse(TestCase):
+    def test_traverse_shallow(self) -> None:
+        state_dict = {
+            "key0": 1,
+            "key1": [1, 2],
+            "key2": {1: 2, 2: 3},
+            "key3": torch.tensor([1]),
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(("key0",), data)
+        self.assertEqual(data[("key0",)], 1)
+
+        self.assertIn(("key1",), data)
+        self.assertEqual(data[("key1",)], [1, 2])
+
+        self.assertIn(("key2",), data)
+        self.assertEqual(data[("key2",)], {1: 2, 2: 3})
+
+        self.assertIn(("key3",), data)
+        self.assertEqual(data[("key3",)], torch.tensor([1]))
+
+    def test_traverse_nested_list(self) -> None:
+        state_dict = {
+            "key1": [
+                torch.tensor([1]),
+                [
+                    33,
+                    torch.tensor([2]),
+                    [44, 55],
+                ],
+                [66, 77],
+            ],
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertNotIn(("key1",), data)
+
+        self.assertIn(
+            (
+                "key1",
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    0,
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    0,
+                )
+            ],
+            33,
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                1,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    1,
+                )
+            ],
+            torch.tensor([2]),
+        )
+
+        self.assertIn(
+            (
+                "key1",
+                1,
+                2,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    1,
+                    2,
+                )
+            ],
+            [44, 55],
+        )
+        self.assertNotIn(("key1", 1, 2, 0), data)
+
+        self.assertIn(
+            (
+                "key1",
+                2,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key1",
+                    2,
+                )
+            ],
+            [66, 77],
+        )
+
+    def test_traverse_nested_dict(self) -> None:
+        state_dict = {
+            "key0": {
+                "key1": 99,
+                "key2": torch.tensor([1]),
+            },
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertNotIn(("key0",), data)
+
+        self.assertIn(
+            (
+                "key0",
+                "key1",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    "key1",
+                )
+            ],
+            99,
+        )
+
+        self.assertIn(
+            (
+                "key0",
+                "key2",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    "key2",
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+    def test_traverse_doesnt_ignore_intermediate_collections(self) -> None:
+        state_dict: STATE_DICT_TYPE = {
+            "key0": [{"key1": {"key2": torch.tensor([1])}}]
+        }
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(
+            (
+                "key0",
+                0,
+                "key1",
+                "key2",
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    0,
+                    "key1",
+                    "key2",
+                )
+            ],
+            torch.tensor([1]),
+        )
+
+    def test_traverse_with_ordered_dict(self) -> None:
+        state_dict = OrderedDict(
+            {
+                "key0": [
+                    99,
+                    torch.tensor([3]),
+                ]
+            }
+        )
+
+        data = {}
+
+        def collect_data(path, value):
+            nonlocal data
+            data[path] = value
+
+        tv.traverse_state_dict(state_dict, collect_data)
+
+        self.assertIn(
+            (
+                "key0",
+                0,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    0,
+                )
+            ],
+            99,
+        )
+
+        self.assertIn(
+            (
+                "key0",
+                1,
+            ),
+            data,
+        )
+        self.assertEqual(
+            data[
+                (
+                    "key0",
+                    1,
+                )
+            ],
+            torch.tensor([3]),
+        )
+
+    def test_set_element(self) -> None:
+        state_dict: STATE_DICT_TYPE = {}
+
+        tv.set_element(state_dict, ("k",), 10)
+        self.assertEqual(state_dict["k"], 10)
+
+        tv.set_element(state_dict, ("k1", 2), 1)
+        self.assertEqual(state_dict["k1"], [None, None, 1])
+
+        tv.set_element(state_dict, ("k1", 1), 99)
+        self.assertEqual(state_dict["k1"], [None, 99, 1])
+
+        tv.set_element(state_dict, ("k1", 3), 88)
+        self.assertEqual(state_dict["k1"], [None, 99, 1, 88])
+
+        tv.set_element(state_dict, ("k2", "k3"), 3)
+        self.assertEqual(state_dict["k2"], {"k3": 3})
+
+        tv.set_element(state_dict, ("k2", "k4", 0, 0), 99)
+        self.assertEqual(state_dict["k2"]["k4"][0], [99])
+
+    def test_get_element(self) -> None:
+        state_dict = {"a": [0, 1], "b": [2, {"c": "d"}]}
+        self.assertEqual(tv.get_element(state_dict, ("a",)), [0, 1])
+        self.assertEqual(
+            tv.get_element(
+                state_dict,
+                (
+                    "b",
+                    0,
+                ),
+            ),
+            2,
+        )
+        self.assertEqual(
+            tv.get_element(
+                state_dict,
+                (
+                    "b",
+                    1,
+                    "c",
+                ),
+            ),
+            "d",
+        )
+
+        self.assertIsNone(tv.get_element(state_dict, ("c",)))
+        self.assertIsNone(tv.get_element(state_dict, ("a", 33)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 88)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 0, 2)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 1, 2)))
+        self.assertIsNone(tv.get_element(state_dict, ("b", 1, "d")))
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
This is a huge collection of changes to DCP. In no particular order:

Two kitchen-sync Planners that effectively replace the default ones from PTD and provide the following set of features:

1)nested state dict handling.
This is a quite common scenario and is essential to enable any optimizer state checkpointing.

2)nested ShardedTensor flattening
This is the core feature that enables 2D checkpointing as FSDP will produce them in 2d mode

- dedup replicated tensors
This happens when using DT with Replicated placement.

FSDP-based optimizer loading.
load_sharded_optimizer_state_dict handles 1D and 2D loading transparently.
It won't work when FSDP is not used so that needs to be addressed.

Finally, it's a tech demo of how to compose multiple checkpoint transformations.