### PR TITLE
[spmd] change pyre search strategy and remove pyre lint on tests

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,15 +1,10 @@
 {
   "strict": true,
-  "site_package_search_strategy": "pep561",
+  "site_package_search_strategy": "all",
   "source_directories": [
     {
       "import_root": ".",
       "source": "spmd"
-    },
-    {
-      "import_root": "test",
-      "source": "test/spmd"
     }
   ]
 }
-

--- a/spmd/tensor/dispatch.py
+++ b/spmd/tensor/dispatch.py
@@ -4,10 +4,7 @@ from typing import List, Callable, Dict, Tuple, Optional, cast
 
 import torch
 from torch.utils._pytree import tree_map
-from torchgen.model import (  # pyre-ignore[21]: Undefined import
-    FunctionSchema,
-    SchemaKind,
-)
+from torchgen.model import FunctionSchema, SchemaKind
 
 import spmd.tensor.api as dtensor
 from spmd.tensor.placement_types import DTensorSpec, OutputSpecType
@@ -207,12 +204,12 @@ def operator_dispatch(
         local_tensor_kwargs = cast(Dict[str, object], local_tensor_kwargs)
         local_results = op_call(*local_tensor_args, **local_tensor_kwargs)
 
-        if schema_kind == SchemaKind.inplace:
+        if schema_kind == SchemaKind.inplace:  # pyre-ignore [16] pyre bad at enum
             # inplace op should return self instead of re-wrapping
             self = cast(dtensor.DTensor, args[0])
             self._spec = cast(DTensorSpec, output_sharding.output_spec)
             return self
-        elif schema_kind == SchemaKind.out:
+        elif schema_kind == SchemaKind.out:  # pyre-ignore [16] pyre bad at enum
             # out variant could possibly have multiple out args (i.e. lu_unpack.out)
             output_specs = (
                 (output_sharding.output_spec,)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #519
* __->__ #518

This PR:
1. changes pyre search strategy to all, this is because a lot
of the pytorch code (i.e. FunctionSchema) is not type annotated and
therefore pyre simply treat them as missing annotation, which is not
nice. change to "all" allow pyre use un-typed class as annotation
2. remove pyre check on tests as we don't need strong type annotation
on tests