### PR TITLE
[dtensor] Enforce sharding for inplace/out_variant ops

### DIFF
--- a/spmd/tensor/ops/common_rules.py
+++ b/spmd/tensor/ops/common_rules.py
@@ -2,7 +2,7 @@
 import math
 
 import torch
-from typing import List, Dict, Tuple, cast
+from typing import List, Dict, Tuple, Optional, cast
 from spmd.tensor.dispatch import OpSchema, OutputSharding
 from spmd.tensor.placement_types import DTensorSpec
 from spmd.tensor.ops.utils import as_list
@@ -29,6 +29,7 @@ def _inplace_rewrap_schema_suggestion(
 
 
 def _gen_reshard_suggestions(
+    op_schema: OpSchema,
     input_dims: List[str],
     input_specs: Tuple[DTensorSpec, ...],
     dim_to_sharding: Dict[str, int],
@@ -47,13 +48,19 @@ def _gen_reshard_suggestions(
         )
     return OutputSharding(
         None,
-        schema_suggestions=[OpSchema(tuple(suggested_arg_specs), {})],
+        schema_suggestions=[
+            OpSchema(op_schema.func_schema, tuple(suggested_arg_specs), {})
+        ],
         failed_reason="Input placements op sharding propagation failed, need to reshard!",
     )
 
 
 def einop_rule(
-    equation: str, op_schema: OpSchema, linearity: bool = False
+    equation: str,
+    op_schema: OpSchema,
+    *,
+    linearity: bool = False,
+    enforce_sharding: Optional[Dict[str, int]] = None,
 ) -> OutputSharding:
     """
     Propagate the sharding of inputs to output for ops whose data
@@ -87,7 +94,7 @@ def einop_rule(
         # replicate and shard to shard, but this will trigger an reshard operation
         if a != b:
             if a == -1 or b == -1:
-                # rehsard the replicate to match the sharded one
+                # reshard the replicate to match the sharded one
                 nonlocal needs_reshard
                 needs_reshard = True
                 return a if a != -1 else b
@@ -114,17 +121,12 @@ def einop_rule(
         for idx, (dim, mesh_dim) in enumerate(
             zip(input_dim, input_spec.dim_map)
         ):
-            if mesh_dim != -1:
-                if (
-                    mesh_dim in seen_shardings
-                    and dim != seen_shardings[mesh_dim]
-                ):
+            if enforce_sharding and dim in enforce_sharding:
+                if enforce_sharding[dim] != mesh_dim:
                     needs_reshard = True
-                    seen_shardings[mesh_dim] += dim
-                else:
-                    seen_shardings[mesh_dim] = dim
-
-            if dim not in dim_to_sharding:
+                dim_to_sharding[dim] = enforce_sharding[dim]
+                dim_to_size[dim] = input_spec.shape[idx]
+            elif dim not in dim_to_sharding:
                 dim_to_sharding[dim] = mesh_dim
                 dim_to_size[dim] = input_spec.shape[idx]
             else:
@@ -133,11 +135,24 @@ def einop_rule(
                 )
                 assert dim_to_size[dim] == input_spec.shape[idx]
 
+            # after merging sharding, we check if there're multiple
+            # sharding on the same mesh dim.
+            merged_sharding_for_dim = dim_to_sharding[dim]
+            if merged_sharding_for_dim != -1:
+                if (
+                    merged_sharding_for_dim in seen_shardings
+                    and dim != seen_shardings[merged_sharding_for_dim]
+                ):
+                    needs_reshard = True
+                    seen_shardings[merged_sharding_for_dim] += dim
+                else:
+                    seen_shardings[merged_sharding_for_dim] = dim
+
     if pending_sums_counter and not linearity:
         # return reshard suggestion with no pending sum, because we already properly
         # merge the sharding, this reshard suggestion is legit to use
         return _gen_reshard_suggestions(
-            input_dims, input_specs, dim_to_sharding, []
+            op_schema, input_dims, input_specs, dim_to_sharding, []
         )
     else:
         # It's a op that support linearity, but not all input arguments are partial
@@ -161,7 +176,8 @@ def einop_rule(
                 for input_dim, input_spec in zip(input_dims, input_specs):
                     if (
                         d in input_dim
-                        and input_spec.dim_map[input_dim.index(d)] == mesh_dim
+                        and input_spec.dim_map[input_dim.index(d)]
+                        == mesh_dim
                     ):
                         cost += math.prod(
                             input_spec.local_shape
@@ -177,7 +193,7 @@ def einop_rule(
     pending_sums = list(pending_sums_counter.keys())
     if needs_reshard:
         return _gen_reshard_suggestions(
-            input_dims, input_specs, dim_to_sharding, pending_sums
+            op_schema, input_dims, input_specs, dim_to_sharding, pending_sums
         )
 
     # if no need to reshard, we directly generate the output sharding
@@ -238,8 +254,25 @@ def pointwise_rule(
             )
 
     fmt = f"{','.join(p for p in dimchars)}->{out_dimchars}"
-    einop_schema = OpSchema(input_specs, {})
-    output_sharding = einop_rule(fmt, einop_schema, linearity=linearity)
+    einop_schema = OpSchema(op_schema.func_schema, input_specs, {})
+
+    enforce_sharding: Dict[str, int] = {}
+    if op_schema.is_inplace:
+        # inplace op should keep the input sharding it writes to
+        for out_dimchar, mesh_dim in zip(out_dimchars, input_specs[0].dim_map):
+            enforce_sharding[out_dimchar] = mesh_dim
+
+    elif op_schema.is_out_variant:
+        out_spec = cast(DTensorSpec, op_schema.kwargs_schema["out"])
+        for out_dimchar, mesh_dim in zip(out_dimchars, out_spec.dim_map):
+            enforce_sharding[out_dimchar] = mesh_dim
+
+    output_sharding = einop_rule(
+        fmt,
+        einop_schema,
+        linearity=linearity,
+        enforce_sharding=enforce_sharding,
+    )
     if (
         output_sharding.output_spec is None
         and output_sharding.schema_suggestions is not None

--- a/spmd/tensor/ops/tensor_ops.py
+++ b/spmd/tensor/ops/tensor_ops.py
@@ -134,6 +134,7 @@ def prop_bucketize(op_schema: OpSchema) -> OutputSharding:
             output_spec=None,
             schema_suggestions=[
                 OpSchema(
+                    func_schema=op_schema.func_schema,
                     args_schema=(
                         input_schema,
                         DTensorSpec(
@@ -191,6 +192,7 @@ def _prop_all_but_dim(
             output_spec=None,
             schema_suggestions=[
                 OpSchema(
+                    func_schema=op_schema.func_schema,
                     args_schema=(suggested_input_spec,)
                     + op_schema.args_schema[1:],
                     kwargs_schema=op_schema.kwargs_schema,
@@ -287,6 +289,7 @@ def prop_slice_scatter(op_schema: OpSchema) -> OutputSharding:
             output_spec=None,
             schema_suggestions=[
                 OpSchema(
+                    func_schema=op_schema.func_schema,
                     args_schema=(
                         DTensorSpec(
                             mesh=input.mesh,
@@ -322,6 +325,7 @@ def prop_index_select(op_schema: OpSchema) -> OutputSharding:
 
     result = prop_index(
         OpSchema(
+            func_schema=op_schema.func_schema,
             args_schema=(values_spec, all_indices_spec),
             kwargs_schema=op_schema.kwargs_schema,
         )
@@ -329,6 +333,7 @@ def prop_index_select(op_schema: OpSchema) -> OutputSharding:
     if result.schema_suggestions:
         result.schema_suggestions = [
             OpSchema(
+                func_schema=op_schema.func_schema,
                 args_schema=(s.args_schema[0], dim, s.args_schema[1][dim]),
                 kwargs_schema=op_schema.kwargs_schema,
             )
@@ -365,6 +370,7 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
     #    Here, we piggyback on the pointwise sharding rule for indices.
     indices_out = pointwise_rule(
         OpSchema(
+            func_schema=op_schema.func_schema,
             args_schema=tuple(v[1] for v in valid_indices_spec),
             kwargs_schema={},
         )
@@ -453,6 +459,7 @@ def prop_index(op_schema: OpSchema) -> OutputSharding:
             output_spec=None,
             schema_suggestions=[
                 OpSchema(
+                    func_schema=op_schema.func_schema,
                     args_schema=(
                         DTensorSpec(
                             mesh=values_spec.mesh,

--- a/test/spmd/tensor/test_common_rules.py
+++ b/test/spmd/tensor/test_common_rules.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 from torch.testing._internal.common_utils import run_tests
+from torchgen.model import FunctionSchema  # pyre-ignore[21]: Undefined import
 from spmd.tensor.dispatch import OpSchema
 
 from spmd.tensor.ops.common_rules import (
@@ -17,11 +18,17 @@ from spmd import DeviceMesh
 
 
 class CommonRulesTest(DistTensorTestBase):
+    def parse_schema(self, schema_str):
+        return FunctionSchema.parse(schema_str)
+
     @with_comms
     def test_einop_basic_propagation(self):
         # plain einsum, mm
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
+        func_schema = self.parse_schema(
+            "aten::mm(Tensor self, Tensor mat2) -> Tensor"
+        )
         # propagate col-wise sharding
         mat1, mat2 = [-1, -1], [-1, 0]
         mat1_spec = DTensorSpec.from_dim_map(
@@ -31,7 +38,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, mat2, [], shape=torch.Size([4, 8])
         )
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -47,7 +54,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, mat2, [], shape=torch.Size([4, 8])
         )
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -63,7 +70,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, mat2, [], shape=torch.Size([4, 8])
         )
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -73,13 +80,17 @@ class CommonRulesTest(DistTensorTestBase):
     @with_comms
     def test_einop_pointwise_propagation(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        func_schema = self.parse_schema(
+            "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
+        )
         # addition
         mat1 = [0, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [], shape=torch.Size([8, 8])
         )
         output_sharding = einop_rule(
-            "ij,ij->ij", OpSchema((mat1_spec, mat1_spec), {})
+            "ij,ij->ij", OpSchema(func_schema, (mat1_spec, mat1_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -95,7 +106,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, [-1], [], shape=torch.Size([2])
         )
         output_sharding = einop_rule(
-            "ijk,k->ijk", OpSchema((mat1_spec, mat2_spec), {})
+            "ijk,k->ijk", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -110,7 +121,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, [-1, -1], [], shape=torch.Size([1, 8])
         )
         output_sharding = einop_rule(
-            "ijk,1k->ijk", OpSchema((mat1_spec, mat2_spec), {})
+            "ijk,1k->ijk", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -124,6 +135,11 @@ class CommonRulesTest(DistTensorTestBase):
             self.world_size // 2, self.world_size // 2
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
+
+        func_schema = self.parse_schema(
+            "aten::mm(Tensor self, Tensor mat2) -> Tensor"
+        )
+
         mat1, mat2 = [0, -1], [-1, 1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [], shape=torch.Size([8, 4])
@@ -132,7 +148,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, mat2, [], shape=torch.Size([4, 8])
         )
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
@@ -146,6 +162,10 @@ class CommonRulesTest(DistTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
+        mm_func_schema = self.parse_schema(
+            "aten::mm(Tensor self, Tensor mat2) -> Tensor"
+        )
+
         mat1, mat2 = [0, -1], [-1, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [1], shape=torch.Size([8, 4])
@@ -156,7 +176,7 @@ class CommonRulesTest(DistTensorTestBase):
         # if not turn on linearity, partial sum is not eligible to propagate, we return
         # suggestion to reshard inputs with no partial sum (i.e. all_reduce one input)
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(mm_func_schema, (mat1_spec, mat2_spec), {})
         )
         self.assertIsNone(output_sharding.output_spec)
         suggestions = output_sharding.schema_suggestions
@@ -167,7 +187,9 @@ class CommonRulesTest(DistTensorTestBase):
         # einop prop with linearity on mm, should give back suggestion
         # on converting placements to partial
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {}), linearity=True
+            "mk,kn->mn",
+            OpSchema(mm_func_schema, (mat1_spec, mat2_spec), {}),
+            linearity=True,
         )
         self.assertIsNone(output_sharding.output_spec)
         suggestions = output_sharding.schema_suggestions
@@ -178,6 +200,9 @@ class CommonRulesTest(DistTensorTestBase):
 
         # einop prop with linearity on point-wise, should give back suggestion
         # on converting placements to partial
+        add_func_schema = self.parse_schema(
+            "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
+        )
         mat1, mat2 = [0, -1], [0, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [1], shape=torch.Size([8, 6])
@@ -187,7 +212,9 @@ class CommonRulesTest(DistTensorTestBase):
         )
 
         output_sharding = einop_rule(
-            "ij,ij->ij", OpSchema((mat1_spec, mat2_spec), {}), linearity=True
+            "ij,ij->ij",
+            OpSchema(add_func_schema, (mat1_spec, mat2_spec), {}),
+            linearity=True,
         )
         self.assertIsNone(output_sharding.output_spec)
         suggestions = output_sharding.schema_suggestions
@@ -201,6 +228,10 @@ class CommonRulesTest(DistTensorTestBase):
         # einop prop with multi sharding on same mesh dim
         mesh_shape = torch.arange(self.world_size)
         mesh = DeviceMesh(self.device_type, mesh_shape)
+
+        func_schema = self.parse_schema(
+            "aten::mm(Tensor self, Tensor mat2) -> Tensor"
+        )
         mat1, mat2 = [0, -1], [0, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [], shape=torch.Size([8, 12])
@@ -209,7 +240,7 @@ class CommonRulesTest(DistTensorTestBase):
             mesh, mat2, [], shape=torch.Size([12, 4])
         )
         output_sharding = einop_rule(
-            "mk,kn->mn", OpSchema((mat1_spec, mat2_spec), {})
+            "mk,kn->mn", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
         )
         output_spec = output_sharding.output_spec
         self.assertIsNone(output_spec)
@@ -228,6 +259,9 @@ class CommonRulesTest(DistTensorTestBase):
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
 
+        func_schema = self.parse_schema(
+            "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
+        )
         mat1, mat2 = [0, -1], [1, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [], shape=torch.Size([8, 4])
@@ -239,12 +273,17 @@ class CommonRulesTest(DistTensorTestBase):
         with self.assertRaisesRegex(
             RuntimeError, "sharded two different ways:"
         ):
-            einop_rule("ij,ij->ij", OpSchema((mat1_spec, mat2_spec), {}))
+            einop_rule(
+                "ij,ij->ij", OpSchema(func_schema, (mat1_spec, mat2_spec), {})
+            )
 
     @with_comms
     def test_pointwise_rules_suggestion(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 
+        func_schema = self.parse_schema(
+            "aten::lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor"
+        )
         # propagate point-wise sharding
         inp1, inp2 = [-1, -1], [-1, 0]
         mat1_spec = DTensorSpec.from_dim_map(
@@ -255,7 +294,7 @@ class CommonRulesTest(DistTensorTestBase):
         )
         # adding a positional argument -1 to arg schema
         output_sharding = pointwise_rule(
-            OpSchema((mat1_spec, mat2_spec, -1), {})
+            OpSchema(func_schema, (mat1_spec, mat2_spec, -1), {})
         )
         self.assertIsNone(output_sharding.output_spec)
         self.assertIsNotNone(output_sharding.schema_suggestions)
@@ -268,11 +307,16 @@ class CommonRulesTest(DistTensorTestBase):
 
     @with_comms
     def test_pointwise_multi_sharding_on_mesh_dim(self):
-        # 2d mesh einop sharding
+        # 2d mesh pointwise sharding
         mesh_shape = torch.arange(self.world_size).reshape(
             self.world_size // 2, self.world_size // 2
         )
         mesh = DeviceMesh(self.device_type, mesh_shape)
+
+        func_schema = self.parse_schema(
+            "aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"
+        )
+
         # basic case to test implicit broadcasting shape alignment
         mat1, mat2 = [-1, 0], [0]
         mat1_spec = DTensorSpec.from_dim_map(
@@ -281,7 +325,9 @@ class CommonRulesTest(DistTensorTestBase):
         mat2_spec = DTensorSpec.from_dim_map(
             mesh, mat2, [], shape=torch.Size([6])
         )
-        output_sharding = pointwise_rule(OpSchema((mat1_spec, mat2_spec), {}))
+        output_sharding = pointwise_rule(
+            OpSchema(func_schema, (mat1_spec, mat2_spec), {})
+        )
         output_spec = output_sharding.output_spec
         self.assertIsNotNone(output_spec)
         self.assertEqual(output_spec.dim_map, [-1, 0])
@@ -294,7 +340,9 @@ class CommonRulesTest(DistTensorTestBase):
         mat2_spec = DTensorSpec.from_dim_map(
             mesh, mat2, [], shape=torch.Size([12, 4, 8])
         )
-        output_sharding = pointwise_rule(OpSchema((mat1_spec, mat2_spec), {}))
+        output_sharding = pointwise_rule(
+            OpSchema(func_schema, (mat1_spec, mat2_spec), {})
+        )
         output_spec = output_sharding.output_spec
         self.assertIsNone(output_spec)
         self.assertIsNotNone(output_sharding.schema_suggestions)
@@ -308,15 +356,55 @@ class CommonRulesTest(DistTensorTestBase):
         self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat2)
 
     @with_comms
+    def test_pointwise_enforce_sharding_multi_sharding_on_mesh_dim(self):
+        # 2d mesh pointwise sharding
+        mesh_shape = torch.arange(self.world_size).reshape(
+            self.world_size // 2, self.world_size // 2
+        )
+        mesh = DeviceMesh(self.device_type, mesh_shape)
+
+        func_schema = self.parse_schema(
+            "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)"
+        )
+
+        # more advanced case that needs reshard one input to align sharding
+        mat1, mat2 = [0, -1, 1], [-1, -1, 0]
+        mat1_spec = DTensorSpec.from_dim_map(
+            mesh, mat1, [], shape=torch.Size([12, 4, 8])
+        )
+        mat2_spec = DTensorSpec.from_dim_map(
+            mesh, mat2, [], shape=torch.Size([12, 1, 8])
+        )
+        print(f">> mat1 spec: {mat1_spec}")
+        output_sharding = pointwise_rule(
+            OpSchema(func_schema, (mat1_spec, mat2_spec), {})
+        )
+        output_spec = output_sharding.output_spec
+        self.assertIsNone(output_spec)
+        self.assertIsNotNone(output_sharding.schema_suggestions)
+
+        # ensure that the suggestion is to reshard the second
+        # arg as we should enforce the sharding of the first arg
+        schema_suggestion = output_sharding.schema_suggestions[0]
+        self.assertEqual(schema_suggestion.args_schema[0].dim_map, mat1)
+        self.assertEqual(schema_suggestion.args_schema[1].dim_map, mat1)
+
+    @with_comms
     def test_reduction_rule(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        func_schema = self.parse_schema(
+            "aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor"
+        )
         # reduction on a 2d mat
         mat1 = [0, -1]
         mat1_spec = DTensorSpec.from_dim_map(
             mesh, mat1, [], shape=torch.Size([8, 4])
         )
         # reduction on dim 0
-        output_sharding_0 = reduction_rule(OpSchema((mat1_spec, 0), {}))
+        output_sharding_0 = reduction_rule(
+            OpSchema(func_schema, (mat1_spec, 0), {})
+        )
         self.assertIsNotNone(output_sharding_0.output_spec)
         self.assertEqual(output_sharding_0.output_spec.dim_map, [-1])
         # pending sum on dim 0
@@ -324,14 +412,18 @@ class CommonRulesTest(DistTensorTestBase):
         self.assertEqual(output_sharding_0.output_spec.shape, torch.Size([4]))
 
         # reduction on dim 1
-        output_sharding_1 = reduction_rule(OpSchema((mat1_spec, 1), {}))
+        output_sharding_1 = reduction_rule(
+            OpSchema(func_schema, (mat1_spec, 1), {})
+        )
         self.assertIsNotNone(output_sharding_1.output_spec)
         self.assertEqual(output_sharding_1.output_spec.dim_map, [0])
         self.assertEqual(output_sharding_1.output_spec.sums, [])
         self.assertEqual(output_sharding_1.output_spec.shape, torch.Size([8]))
 
         # full reduction if not specify dim
-        output_sharding_all_dim = reduction_rule(OpSchema((mat1_spec,), {}))
+        output_sharding_all_dim = reduction_rule(
+            OpSchema(func_schema, (mat1_spec,), {})
+        )
         self.assertIsNotNone(output_sharding_all_dim.output_spec)
         self.assertEqual(output_sharding_all_dim.output_spec.dim_map, [])
         # pending sum on mesh

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -285,31 +285,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         self.assertEqual(input_tensor, dtensor.to_local())
         self.assertEqual(expected, dt.to_local())
 
-    @with_comms
-    def test_pointwise_rules_suggestion(self):
-        device_mesh = self.common_device_mesh()
-
-        # propagate point-wise sharding
-        inp1, inp2 = [-1, -1], [-1, 0]
-        mat1_spec = DTensorSpec.from_dim_map(
-            device_mesh, inp1, [], shape=torch.Size([8, 4])
-        )
-        mat2_spec = DTensorSpec.from_dim_map(
-            device_mesh, inp2, [], shape=torch.Size([8, 4])
-        )
-        # adding a positional argument -1 to arg schema
-        output_sharding = pointwise_rule(
-            OpSchema((mat1_spec, mat2_spec, -1), {})
-        )
-        self.assertIsNone(output_sharding.output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
-
-        # ensure that the suggestion from pointwise rules still have
-        # the positional args that are not DTensorSpec
-        schema_suggestion = output_sharding.schema_suggestions[0]
-        self.assertEqual(len(schema_suggestion.args_schema), 3)
-        self.assertEqual(schema_suggestion.args_schema[2], -1)
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/spmd/tensor/test_tensor_ops.py
+++ b/test/spmd/tensor/test_tensor_ops.py
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+from math import exp
 import torch
 from torch.testing._internal.common_utils import run_tests
 from spmd.testing.common_utils import (  # type: ignore
@@ -85,16 +86,38 @@ class DistTensorOpsTest(DistTensorTestBase):
         self.assertTrue(mul_res is dt_to_mul)
         self.assertEqual(mul_res.to_local(), expected_mul_dt.to_local())
 
+        # test inplace op self and other dtensor with other specs
+        # and make sure out spec not change
+        shard_spec = [Shard(0)]
+        partial_spec = [_Partial()]
+        dt_to_inplace_add = distribute_tensor(input_tensor, mesh, shard_spec)
+        partial_grad = DTensor.from_local(
+            torch.randn(12, 3), mesh, partial_spec
+        )
+        res = dt_to_inplace_add.add_(partial_grad)
+        self.assertTrue(res is dt_to_inplace_add)
+        self.assertTrue(res.placements == shard_spec)
+
     @with_comms
     def test_op_out_variant(self):
         mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
         input_tensor = torch.randn((12, 3), device=self.device_type)
-        dist_tensor_out = distribute_tensor(input_tensor, mesh, [Shard(0)])
-        expected_dt = dist_tensor_out.clone() + 3
-        res = torch.add(dist_tensor_out, 3, out=dist_tensor_out)
+        sharded_dt_input = distribute_tensor(input_tensor, mesh, [Shard(0)])
+        expected_dt = sharded_dt_input.clone() + 3
+        sharded_dt_out = sharded_dt_input.clone()
+        res = torch.add(sharded_dt_input, 3, out=sharded_dt_out)
         # op out variant should be the same instance before and after
-        self.assertTrue(res is dist_tensor_out)
-        self.assertEqual(dist_tensor_out.to_local(), expected_dt.to_local())
+        self.assertTrue(res is sharded_dt_out)
+        self.assertEqual(sharded_dt_out.to_local(), expected_dt.to_local())
+
+        # test op out variant with other spec and make sure out spec not change
+        replica_spec = [Replicate()]
+        replicate_out = distribute_tensor(input_tensor, mesh, replica_spec)
+        expected_dt = replicate_out.clone() + 3
+        res = torch.add(sharded_dt_input, 3, out=replicate_out)
+        self.assertTrue(res is replicate_out)
+        self.assertTrue(res.placements == replica_spec)
+        self.assertEqual(replicate_out.to_local(), expected_dt.to_local())
 
     @with_comms
     def test_empty_like(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

For inplace ops and ops with out variant, the correct behavior is to
preserve the sharding of the DTensor we write into, as it matches to
the case of shape property too. In this PR, we enforce the sharding
for inplace/out_variant ops by introducing a enforce sharding check for
einop/pointwise rule, where it takes a enforce sharding dict and use
that to do sharding propagations