### PR TITLE
Skip data parallel init when data parallel group size = 1

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1027,7 +1027,7 @@ class PipelineDriverBase(torch.nn.Module):
     """
     def init_data_parallel(self, dp_group_size, dp_pg_cb=None):
         if dp_group_size <= 1:
-            logging.info(f'[root] Data parallel group size <= 1, skipping data parallel initialization')
+            logging.info('[root] Data parallel group size <= 1, skipping data parallel initialization')
             return
 
         n_stages = len(self.stage_to_executor)

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1026,6 +1026,10 @@ class PipelineDriverBase(torch.nn.Module):
                   user can use this Callable to pass in prepared data parallel groups
     """
     def init_data_parallel(self, dp_group_size, dp_pg_cb=None):
+        if dp_group_size <= 1:
+            logging.info(f'[root] Data parallel group size <= 1, skipping data parallel initialization')
+            return
+
         n_stages = len(self.stage_to_executor)
         logging.info(f'[root] Initializing {n_stages} data parallel groups, each of size {dp_group_size}')
         futs = []


### PR DESCRIPTION
Skip the data parallel init to save init of NCCL communicator