### PR TITLE
Add env PIPPY_PIN_DEVICE

### DIFF
--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -8,6 +8,8 @@ import logging
 # 1. Needed to work around the issue of RPC not automatically pinning spawned worker threads to CUDA device of the main
 # thread
 # 2. Must be done before `import torch` at which point CUDA context may be created
+# 3. Currently this is enabled by default (as long as #1 is not implemented in RPC). Users may set `PIPPY_PIN_DEVICE` to
+# 0 to disable the pinning
 if os.getenv('PIPPY_PIN_DEVICE', '1') == '1':
     cuda_devices_str = os.getenv('CUDA_VISIBLE_DEVICES')
     if (cuda_devices_str is None                        # not set

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -8,14 +8,15 @@ import logging
 # 1. Needed to work around the issue of RPC not automatically pinning spawned worker threads to CUDA device of the main
 # thread
 # 2. Must be done before `import torch` at which point CUDA context may be created
-cuda_devices_str = os.getenv('CUDA_VISIBLE_DEVICES')
-if (cuda_devices_str is None                        # not set
-        or len(cuda_devices_str.split(',')) > 1):   # or set to all devices
-    # If launchers like Torchrun sets `LOCAL_RANK`, we would use this information
-    local_rank_str = os.getenv('LOCAL_RANK')
-    if local_rank_str is not None:
-        os.environ['CUDA_VISIBLE_DEVICES'] = local_rank_str
-        print(f"Pinning local process {local_rank_str} to gpu {os.getenv('CUDA_VISIBLE_DEVICES')}")
+if os.getenv('PIPPY_PIN_DEVICE', '1') == '1':
+    cuda_devices_str = os.getenv('CUDA_VISIBLE_DEVICES')
+    if (cuda_devices_str is None                        # not set
+            or len(cuda_devices_str.split(',')) > 1):   # or set to all devices
+        # If launchers like Torchrun sets `LOCAL_RANK`, we would use this information
+        local_rank_str = os.getenv('LOCAL_RANK')
+        if local_rank_str is not None:
+            os.environ['CUDA_VISIBLE_DEVICES'] = local_rank_str
+            print(f"Pinning local process {local_rank_str} to gpu {os.getenv('CUDA_VISIBLE_DEVICES')}")
 
 import torch
 import torch.multiprocessing as mp


### PR DESCRIPTION
When set to 1, pin RPC process to a single CUDA device.
Default value = 1 (same as before).

Adding this env to accept different preferences.

resolves #526 