### PR TITLE
Add split into nstages API

### DIFF
--- a/pippy/ModelSplit.py
+++ b/pippy/ModelSplit.py
@@ -154,6 +154,17 @@ def split_on_size_threshold(
     return _split_on_size_threshold_with_max_stages(mod, threshold)
 
 
+"""
+Split a model into given number of stages, based on equal stage size
+Input:
+  mod: `torch.nn.Module` to split
+  nstages: number of stages to split the module into
+Output:
+  A tuple consisting of:
+      - a `fx.GraphModule` transformed from the input module with `pipe_split` inserted
+"""
+
+
 def split_into_nstages_equal_size(
     mod: torch.nn.Module,
     nstages: int = 1,

--- a/pippy/ModelSplit.py
+++ b/pippy/ModelSplit.py
@@ -177,7 +177,7 @@ def split_into_nstages_equal_size(
         buffer_size += buffer.numel()
 
     total_size = param_size + buffer_size
-    per_stage_size = total_size / nstages
+    per_stage_size = total_size // nstages
     logging.debug(
         f"Total model size: {total_size}, " f"per stage size: {per_stage_size}"
     )

--- a/pippy/ModelSplit.py
+++ b/pippy/ModelSplit.py
@@ -160,8 +160,7 @@ Input:
   mod: `torch.nn.Module` to split
   nstages: number of stages to split the module into
 Output:
-  A tuple consisting of:
-      - a `fx.GraphModule` transformed from the input module with `pipe_split` inserted
+  A `fx.GraphModule` transformed from the input module with `pipe_split` inserted between `nstages` stages
 """
 
 

--- a/pippy/ModelSplit.py
+++ b/pippy/ModelSplit.py
@@ -63,9 +63,7 @@ Output:
 
 
 def _split_on_size_threshold_with_max_stages(
-    mod: torch.nn.Module,
-    threshold: int,
-    max_stages: int = -1
+    mod: torch.nn.Module, threshold: int, max_stages: int = -1
 ) -> Tuple[pippy.fx.GraphModule, int]:
     # Trace the user module to get a graph first
     gm: pippy.fx.GraphModule = pippy.fx.symbolic_trace(mod)
@@ -151,8 +149,7 @@ Output:
 
 
 def split_on_size_threshold(
-    mod: torch.nn.Module,
-    threshold: int
+    mod: torch.nn.Module, threshold: int
 ) -> Tuple[pippy.fx.GraphModule, int]:
     return _split_on_size_threshold_with_max_stages(mod, threshold)
 
@@ -171,14 +168,12 @@ def split_into_nstages_equal_size(
     total_size = param_size + buffer_size
     per_stage_size = total_size / nstages
     logging.debug(
-        f"Total model size: {total_size}, "
-        f"per stage size: {per_stage_size}"
+        f"Total model size: {total_size}, " f"per stage size: {per_stage_size}"
     )
 
     gm, rv_nstages = _split_on_size_threshold_with_max_stages(
-        mod,
-        per_stage_size,
-        nstages)
+        mod, per_stage_size, nstages
+    )
     assert rv_nstages == nstages
 
     return gm

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -36,63 +36,42 @@ if VERBOSE:
 
 pippy.fx.Tracer.proxy_buffer_attributes = True
 
+MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
 
-def run_master(_, args):
-    d_hid = 512
-    bs = 503
 
-    MULTI_USE_PARAM_CONFIG = (
-        MultiUseParameterConfig.REPLICATE
-        if args.replicate
-        else MultiUseParameterConfig.TRANSMIT
-    )
-    print(f"REPLICATE config: {args.replicate} -> {MULTI_USE_PARAM_CONFIG}")
+# Example model definition
+d_hid = 512
+bs = 503
 
-    print("Using schedule:", args.schedule)
+class ExampleCode(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+        self.register_buffer('buffer', torch.randn(bs + 100, d_hid))
 
-    class ExampleCode(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
-            self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
-            self.lin = torch.nn.Linear(d_hid, d_hid)
-            self.register_buffer("buffer", torch.randn(bs + 100, d_hid))
+    def forward(self, x):
+        x = torch.mm(x, self.mm_param)
+        skip_connection = x
+        x = torch.relu(x)
+        x = torch.mm(x, self.mm_param) + self.buffer[:x.shape[0]]
+        x = self.lin(x)
+        x = torch.relu(x)
+        x = x + skip_connection
+        x = torch.mm(x, self.mm_param2)
+        x = self.lin(x)
+        x = torch.relu(x)
+        return {'out': x}
 
-        def forward(self, x):
-            x = torch.mm(x, self.mm_param)
-            skip_connection = x
-            x = torch.relu(x)
-            x = torch.mm(x, self.mm_param) + self.buffer[: x.shape[0]]
-            x = self.lin(x)
-            x = torch.relu(x)
-            x = x + skip_connection
-            x = torch.mm(x, self.mm_param2)
-            x = self.lin(x)
-            x = torch.relu(x)
-            return {"out": x}
 
-    ec = ExampleCode()
-    ec.to(args.device)
-    ec_input = torch.randn(bs, d_hid, device=args.device)
-    ec(ec_input)
-
-    # Auto-split based on size threshold
-    threshold = 300000
-    gm, nstages = pippy.ModelSplit.split_on_size_threshold(ec, threshold)
-    print(f"Model is split into {nstages} stages")
-
-    print(f"\n======= GraphModule after Auto-split =======")
-    print(gm)
-
-    ec_pipe = Pipe.from_tracing(gm, MULTI_USE_PARAM_CONFIG)
-
-    for i, submod in enumerate(ec_pipe.split_gm.children()):
-        print(f"\n======= Child module {i} =======")
-        print(submod)
-
+# Common function to run pipeline with input and check equivalence
+def run_pipe_driver(ec_pipe, args):
     args_chunk_spec = (TensorChunkSpec(0),)
     kwargs_chunk_spec: Dict = {}
     output_chunk_spec = {"out": TensorChunkSpec(0)}
+
+    nstages = len(list(ec_pipe.split_gm.children()))
 
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
@@ -107,6 +86,7 @@ def run_master(_, args):
     )
 
     # # Warm up and correctness runs
+    ec_input = torch.randn(bs, d_hid, device=args.device)
     out = pipe_driver(ec_input)
     ref_out = ec_pipe(ec_input)
 
@@ -136,6 +116,52 @@ def run_master(_, args):
         prof.export_chrome_trace(
             f"{os.path.splitext(os.path.basename(__file__))[0]}.json"
         )
+
+
+def test_split_on_size_threshold(_, args):
+    ec = ExampleCode()
+    ec.to(args.device)
+
+    # Auto-split based on size threshold
+    threshold = 300000
+    gm, nstages = pippy.ModelSplit.split_on_size_threshold(ec, threshold)
+    print(f"Model is split into {nstages} stages")
+
+    print(f"\n======= GraphModule after Auto-split =======")
+    print(gm)
+
+    ec_pipe = Pipe.from_tracing(gm, MULTI_USE_PARAM_CONFIG)
+
+    for i, submod in enumerate(ec_pipe.split_gm.children()):
+        print(f"\n======= Child module {i} =======")
+        print(submod)
+
+    run_pipe_driver(ec_pipe, args)
+
+
+def test_split_into_nstages(_, args):
+    ec = ExampleCode()
+    ec.to(args.device)
+    ec_input = torch.randn(bs, d_hid, device=args.device)
+    ec(ec_input)
+
+    # Auto-split based on given number of stages
+    nstages = 5
+    gm = pippy.ModelSplit.split_into_nstages_equal_size(ec, nstages)
+    print(f'\n======= GraphModule after Auto-split =======')
+    print(gm)
+
+    ec_pipe = Pipe.from_tracing(gm, MULTI_USE_PARAM_CONFIG)
+
+    # Check returned number of stages
+    rv_stages = len(list(ec_pipe.split_gm.children()))
+    assert rv_stages == nstages, f'Model is split into {rv_stages} instead of {nstages} stages'
+
+    for i, submod in enumerate(ec_pipe.split_gm.children()):
+        print(f'\n======= Child module {i} =======')
+        print(submod)
+
+    run_pipe_driver(ec_pipe, args)
 
 
 def main(args=None):
@@ -173,15 +199,22 @@ def main(args=None):
     if args.schedule == "Interleaved1F1B":
         args.world_size = 2
 
-    run_pippy(run_master, args)
+    global MULTI_USE_PARAM_CONFIG
+    if args.replicate:
+        MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.REPLICATE
+    print(f"REPLICATE config: {args.replicate} -> {MULTI_USE_PARAM_CONFIG}")
+    print("Using schedule:", args.schedule)
+
+    run_pippy(test_split_on_size_threshold, args)
+    run_pippy(test_split_into_nstages, args)
 
 
 if __name__ == "__main__":
     main()
 
 
-class LocalTestForwardTest(unittest.TestCase):
-    def test_forward(self):
+class LocalTestAutoSplit(unittest.TestCase):
+    def test_auto_split(self):
         import random
 
         port = random.randint(29500, 30000)


### PR DESCRIPTION
### Added API
```
Split a model into given number of stages, based on equal stage size
Input:
  mod: `torch.nn.Module` to split
  nstages: number of stages to split the module into
Output:
  a `fx.GraphModule` transformed from the input module with `pipe_split` inserted
```

```
def split_into_nstages_equal_size(
    mod: torch.nn.Module,
    nstages: int = 1,
) -> pippy.fx.GraphModule
```

### Implementation
Using the previous `split_on_size_threshold` API as a helper to implement it --
We calculate a total model size, divide it by the number of stages wanted, and use the divided size as the bucket threshold.

### Test
Modified `local_test_autosplit.py` to test this API as well. In the meantime, moved a couple code blocks as a common function.

### Future plan
In longer term, the implementation can be improved to be more like "dynamic programming", but it can be done behind the scene without introducing user-facing changes.