### PR TITLE
Split callbacks

### DIFF
--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -134,9 +134,10 @@ def run_master(pp_ranks, args):
 
     number_of_workers = len(pp_ranks) - pippy.utils.exclude_master
     print(f"number_of_workers = {number_of_workers}")
-    if args.auto_split:
-        # Specify auto_split policy for use by `from_tracing` call later
-        # split_policy = pippy.ModelSplit.split_on_size_threshold(5e6)
+    # Specify auto_split policy for use by `from_tracing` call later
+    if args.auto_split == "threshold":
+        split_policy = pippy.ModelSplit.split_on_size_threshold(490 * 1e6)
+    elif args.auto_split == "equal_size":
         split_policy = pippy.ModelSplit.split_into_equal_size(number_of_workers)
     else:
         # Manually insert split points before `from_tracing` call
@@ -242,7 +243,7 @@ if __name__ == "__main__":
     parser.add_argument('--checkpoint', type=int, default=1, choices=[0, 1])
     parser.add_argument('--pp_group_size', type=int, default=8)
     parser.add_argument('--exclude_master', type=int, default=0, choices=[0, 1])
-    parser.add_argument('--auto_split', type=int, default=0, choices=[0, 1])
+    parser.add_argument('--auto_split', type=str, default="")
     args = parser.parse_args()
 
     assert args.world_size % args.pp_group_size == 0

--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -9,6 +9,7 @@ import torch
 from transformers import T5ForConditionalGeneration, T5Config
 
 import pippy.fx
+import pippy.ModelSplit
 from pippy import run_pippy
 from pippy.IR import MultiUseParameterConfig, Pipe, PipeSplitWrapper, annotate_split_points
 from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B, PipelineDriverInterleaved1F1B, \
@@ -133,7 +134,15 @@ def run_master(pp_ranks, args):
 
     number_of_workers = len(pp_ranks) - pippy.utils.exclude_master
     print(f"number_of_workers = {number_of_workers}")
-    add_split_points(t5, number_of_workers)
+    if args.auto_split:
+        # Specify auto_split policy for use by `from_tracing` call later
+        # split_policy = pippy.ModelSplit.split_on_size_threshold(5e6)
+        split_policy = pippy.ModelSplit.split_into_equal_size(number_of_workers)
+    else:
+        # Manually insert split points before `from_tracing` call
+        add_split_points(t5, number_of_workers)
+        split_policy = None
+
     all_worker_ranks = pp_ranks[pippy.utils.exclude_master:pippy.utils.exclude_master + number_of_workers]
     chunks = len(all_worker_ranks)
     bs = args.batch_size * chunks
@@ -158,7 +167,8 @@ def run_master(pp_ranks, args):
                               # 'past_key_values': False,
                               'encoder_last_hidden_state': False}
     t5_pipe = Pipe.from_tracing(t5, MULTI_USE_PARAM_CONFIG, tracer=PiPPyHFTracer(), concrete_args=concrete_args,
-                                output_loss_value_spec=output_loss_value_spec)
+                                output_loss_value_spec=output_loss_value_spec,
+                                split_policy=split_policy)
     split_gm_children = list(t5_pipe.split_gm.children())
     assert number_of_workers == len(
         split_gm_children), f"number_of_workers = {number_of_workers} len(split_gm_children) = {len(split_gm_children)}"
@@ -232,6 +242,7 @@ if __name__ == "__main__":
     parser.add_argument('--checkpoint', type=int, default=1, choices=[0, 1])
     parser.add_argument('--pp_group_size', type=int, default=8)
     parser.add_argument('--exclude_master', type=int, default=0, choices=[0, 1])
+    parser.add_argument('--auto_split', type=int, default=0, choices=[0, 1])
     args = parser.parse_args()
 
     assert args.world_size % args.pp_group_size == 0

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -942,7 +942,7 @@ class Pipe(torch.nn.Module):
         tracer=None,
         output_loss_value_spec=None,
         deep_copy_module=False,
-        auto_parallel_strategy: Optional[
+        split_policy: Optional[
             Callable[[pippy.fx.GraphModule], pippy.fx.GraphModule]
         ] = None,
         **kwargs,
@@ -980,8 +980,8 @@ class Pipe(torch.nn.Module):
         finally:
             _pipeline_tracer = old__pipeline_tracer
 
-        if auto_parallel_strategy is not None:
-            traced = auto_parallel_strategy(traced)
+        if split_policy is not None:
+            traced = split_policy(traced)
 
         return Pipe._from_traced(
             mod,

--- a/pippy/ModelSplit.py
+++ b/pippy/ModelSplit.py
@@ -63,7 +63,9 @@ Output:
 
 
 def _split_on_size_threshold_with_max_stages(
-    gm: pippy.fx.GraphModule, threshold: int, max_stages: int = -1,
+    gm: pippy.fx.GraphModule,
+    threshold: int,
+    max_stages: int = -1,
 ) -> Tuple[pippy.fx.GraphModule, int]:
     # Analyze size of parameters/buffers used by each node in the graph
     node_param_sizes = _analyze_node_size(gm)
@@ -149,7 +151,7 @@ def split_on_size_threshold(
     threshold: int,
 ) -> Callable[[pippy.fx.GraphModule], pippy.fx.GraphModule]:
     def _split_on_size_threshold(
-        gm: pippy.fx.GraphModule
+        gm: pippy.fx.GraphModule,
     ) -> pippy.fx.GraphModule:
         gm, _ = _split_on_size_threshold_with_max_stages(gm, threshold)
         return gm
@@ -171,7 +173,7 @@ def split_into_equal_size(
     nstages: int = 1,
 ) -> Callable[[pippy.fx.GraphModule], pippy.fx.GraphModule]:
     def _split_into_nstages_equal_size(
-        gm: pippy.fx.GraphModule
+        gm: pippy.fx.GraphModule,
     ) -> pippy.fx.GraphModule:
         param_size = 0
         for param in gm.parameters():
@@ -183,7 +185,8 @@ def split_into_equal_size(
         total_size = param_size + buffer_size
         per_stage_size = total_size // nstages
         logging.debug(
-            f"Total model size: {total_size}, " f"per stage size: {per_stage_size}"
+            f"Total model size: {total_size}, "
+            f"per stage size: {per_stage_size}"
         )
 
         gm, rv_nstages = _split_on_size_threshold_with_max_stages(

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -146,7 +146,9 @@ def test_split_on_size_threshold(_, args):
     # Auto-split based on size threshold
     threshold = 300000
     split_policy = pippy.ModelSplit.split_on_size_threshold(threshold)
-    ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG, split_policy=split_policy)
+    ec_pipe = Pipe.from_tracing(
+        ec, MULTI_USE_PARAM_CONFIG, split_policy=split_policy
+    )
 
     inspect_split_module(ec_pipe, expected_stages=5)
 
@@ -162,7 +164,9 @@ def test_split_into_equal_size(_, args):
     # Auto-split based on given number of stages
     nstages = 5
     split_policy = pippy.ModelSplit.split_into_equal_size(nstages)
-    ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG, split_policy=split_policy)
+    ec_pipe = Pipe.from_tracing(
+        ec, MULTI_USE_PARAM_CONFIG, split_policy=split_policy
+    )
 
     inspect_split_module(ec_pipe, expected_stages=nstages)
 

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -43,6 +43,7 @@ MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
 d_hid = 512
 bs = 503
 
+
 class ExampleCode(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -43,7 +43,6 @@ MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
 d_hid = 512
 bs = 503
 
-
 class ExampleCode(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/test/local_test_forward_auto_parallel.py
+++ b/test/local_test_forward_auto_parallel.py
@@ -82,7 +82,7 @@ def run_master(_, args):
     ec_pipe = Pipe.from_tracing(
         ec,
         MULTI_USE_PARAM_CONFIG,
-        auto_parallel_strategy=dp_auto_parallel(auto_parallel_ctx),
+        split_policy=dp_auto_parallel(auto_parallel_ctx),
     )
     print(ec_pipe.split_gm)
 


### PR DESCRIPTION
### Motivation
To work with custom tracer (such as HF tracer), we need to turn the auto-split methods into callbacks which are callable by the `Pipe.from_tracing(..., tracer=None, ...)` API where user can provide a tracer.

### User-facing changes
Previous programming flow:
```
annotated_mod = pippy.ModelSplit.split_into_nstages_equal_size(mod, nstages)
pipe = Pipe.from_tracing(annotated_mod, MULTI_USE_PARAM_CONFIG)
```

New programming flow:
```
split_policy = pippy.ModelSplit.split_into_equal_size(nstages)
pipe = Pipe.from_tracing(mod, MULTI_USE_PARAM_CONFIG, split_policy=split_policy)
```

Note: The new programming flow is also used by the `[auto_parallelization](https://github.com/pytorch/tau/blob/main/pippy/auto_parallelization.py)` module. So this change makes the APIs in the two cases aligned.

### Test with T5
- Case 1:
```
split_policy = pippy.ModelSplit.split_into_equal_size(nstages=8)
```
```
number_of_workers = 8
submod_0 418M params
submod_1 426M params
submod_2 419M params
submod_3 419M params
submod_4 419M params
submod_5 419M params
submod_6 419M params
submod_7 678M params
total 3620M params
```
- Case 2:
```
split_policy = pippy.ModelSplit.split_on_size_threshold(490 * 1e6)
```
Output:
```
number_of_workers = 8
submod_0 468M params
submod_1 489M params
submod_2 473M params
submod_3 478M params
submod_4 486M params
submod_5 486M params
submod_6 478M params
submod_7 258M params
total 3620M params
```
- Case 3: manual split in `pippy_t5.py`:
```
number_of_workers = 8
submod_0 552M params
submod_1 419M params
submod_2 419M params
submod_3 419M params
submod_4 419M params
submod_5 419M params
submod_6 419M params
submod_7 485M params
total 3554M params
```