### PR TITLE
Remove GPU restriction for tests that can run on CPU.

### DIFF
--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -280,6 +280,7 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         self.assertEqual(expected, dt.to_local())
 
     @with_comms
+    @skip_unless_torch_gpu
     def test_pointwise_rules_suggestion(self):
         device_mesh = self.build_device_mesh()
 

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -279,32 +279,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         self.assertEqual(input_tensor, dtensor.to_local())
         self.assertEqual(expected, dt.to_local())
 
-    @with_comms
-    @skip_unless_torch_gpu
-    def test_pointwise_rules_suggestion(self):
-        device_mesh = self.build_device_mesh()
-
-        # propagate point-wise sharding
-        inp1, inp2 = [-1, -1], [-1, 0]
-        mat1_spec = DTensorSpec.from_dim_map(
-            device_mesh, inp1, [], shape=torch.Size([8, 4])
-        )
-        mat2_spec = DTensorSpec.from_dim_map(
-            device_mesh, inp2, [], shape=torch.Size([8, 4])
-        )
-        # adding a positional argument -1 to arg schema
-        output_sharding = pointwise_rule(
-            OpSchema((mat1_spec, mat2_spec, -1), {})
-        )
-        self.assertIsNone(output_sharding.output_spec)
-        self.assertIsNotNone(output_sharding.schema_suggestions)
-
-        # ensure that the suggestion from pointwise rules still have
-        # the positional args that are not DTensorSpec
-        schema_suggestion = output_sharding.schema_suggestions[0]
-        self.assertEqual(len(schema_suggestion.args_schema), 3)
-        self.assertEqual(schema_suggestion.args_schema[2], -1)
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/spmd/tensor/test_pointwise_ops.py
+++ b/test/spmd/tensor/test_pointwise_ops.py
@@ -147,7 +147,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         )
 
     @with_comms
-    @skip_unless_torch_gpu
     def test_activations(self):
         device_mesh = self.build_device_mesh()
         self._run_sharded_elementwise_ops(
@@ -188,7 +187,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         )
 
     @with_comms
-    @skip_unless_torch_gpu
     @skip(
         "testing RNG based ops is broken: https://github.com/pytorch/tau/issues/494"
     )
@@ -251,7 +249,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         )
 
     @with_comms
-    @skip_unless_torch_gpu
     def test_dropout_errors(self):
         device_mesh = self.build_device_mesh()
         with self.assertRaisesRegex(RuntimeError, "supported"):
@@ -263,7 +260,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
             )
 
     @with_comms
-    @skip_unless_torch_gpu
     def test_mul_out(self):
         device_mesh = self.build_device_mesh()
         torch.manual_seed(self.rank)
@@ -287,7 +283,6 @@ class DistElementwiseOpsTest(DistTensorTestBase):
         self.assertEqual(expected, dt.to_local())
 
     @with_comms
-    @skip_unless_torch_gpu
     def test_pointwise_rules_suggestion(self):
         device_mesh = self.build_device_mesh()
 


### PR DESCRIPTION
Some tests in pairwise ops are valid for CPU, removing the GPU restriction for those tests. 

Test output:
`
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/gnadathur/tau-1
collected 6 items
test/spmd/tensor/test_pointwise_ops.py .ss...                            [100%]
======================== 4 passed, 2 skipped in 19.70s =========================

`