### PR TITLE
[dtensor] more error checking in distribute_tensor API

### DIFF
--- a/spmd/tensor/__init__.py
+++ b/spmd/tensor/__init__.py
@@ -47,6 +47,28 @@ def distribute_tensor(
     if placements is None:
         placements = [Replicate() for _ in range(device_mesh.ndim)]
 
+    if len(placements) != device_mesh.ndim:
+        raise ValueError(
+            f"`placements` must have the same length as `device_mesh.ndim`! "
+            f"Found placements length: {len(placements)}, and device_mesh.ndim: {device_mesh.ndim}."
+        )
+
+    if isinstance(tensor, DTensor):
+        # if the tensor is already a DTensor, we just need to check if the
+        # device mesh and placements are the same
+        if tensor.device_mesh != device_mesh:
+            raise ValueError(
+                f"Cannot distribute a DTensor with device mesh {tensor.device_mesh} "
+                f"to a different device mesh {device_mesh}."
+            )
+        if tensor.placements != placements:
+            raise ValueError(
+                f"Cannot distribute a DTensor with placements {tensor.placements} "
+                f"to a different placements {placements}. do you want to call "
+                f"`redistribute` instead?"
+            )
+        return tensor
+
     # distribute the tensor according to PlacementSpec
     for idx, placement in enumerate(placements):
         if placement.is_shard():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #550
* __->__ #549

more checks:
1. check if placements is same length as device_mesh.ndim
2. check if it's already passed in a dtensor, and with different
  mesh and placements