### PR TITLE
PiPPy + TorchDynamo example

### DIFF
--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -58,6 +58,10 @@ def inspect_split_module(
         print(submod)
 
 
+# For storing reference output from inside compiler
+ref_out = ()
+
+
 def run_master(_, args):
     # PiPPy parameters
     MULTI_USE_PARAM_CONFIG = (

--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -1,0 +1,247 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import argparse
+import logging
+import os
+import unittest
+from typing import Dict
+
+import torch
+import torch.autograd.profiler_legacy
+
+import pippy.fx
+from pippy import run_pippy
+from pippy.IR import MultiUseParameterConfig, Pipe, pipe_split
+from pippy.PipelineDriver import (
+    PipelineDriverBase,
+    PipelineDriverFillDrain,
+    PipelineDriver1F1B,
+    PipelineDriverInterleaved1F1B,
+)
+from pippy.microbatch import TensorChunkSpec
+
+import torchdynamo
+
+PROFILING_ENABLED = True
+CHECK_NUMERIC_EQUIVALENCE = True
+
+schedules = {
+    "FillDrain": PipelineDriverFillDrain,
+    "1F1B": PipelineDriver1F1B,
+    "Interleaved1F1B": PipelineDriverInterleaved1F1B,
+}
+
+VERBOSE = bool(int(os.environ.get("VERBOSE", False)))
+
+if VERBOSE:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+pippy.fx.Tracer.proxy_buffer_attributes = True
+
+
+def inspect_split_module(
+    pipe: Pipe,
+    expected_stages: int = -1,
+):
+    gm: pippy.fx.GraphModule = pipe.split_gm
+    # Check returned number of stages
+    nstages = len(list(gm.children()))
+    if expected_stages > 0:
+        assert (
+            nstages == expected_stages
+        ), f"Model is split into {nstages} instead of {expected_stages} stages"
+
+    print(f"\n======= GraphModule after Auto-split =======")
+    print(gm)
+
+    for i, submod in enumerate(gm.children()):
+        print(f"\n======= Child module {i} =======")
+        print(submod)
+
+
+def run_master(_, args):
+    d_hid = 512
+    bs = 503
+
+    MULTI_USE_PARAM_CONFIG = (
+        MultiUseParameterConfig.REPLICATE
+        if args.replicate
+        else MultiUseParameterConfig.TRANSMIT
+    )
+    print(f"REPLICATE config: {args.replicate} -> {MULTI_USE_PARAM_CONFIG}")
+    print("Using schedule:", args.schedule)
+
+    def my_compiler(gm: torch.fx.GraphModule, example_inputs):
+        print("\n============= my_compiler() called with FX graph =============")
+        gm.graph.print_tabular()
+
+        print("\n============= example inputs =============")
+        print(example_inputs)
+
+        # Run example input
+        input = example_inputs[0]
+        output = gm(input)
+        print("\n============= example output =============")
+        print(output)
+
+        # PiPPy Pipe creation
+        pipe = Pipe.from_tracing(gm, MULTI_USE_PARAM_CONFIG)
+        print("\n============= PiPPy Pipe creation =============")
+
+        inspect_split_module(pipe, 2)
+
+        return pipe   # return a runtime Callable
+
+    class ExampleCode(torch.nn.Module):
+        @torchdynamo.optimize(my_compiler)
+        def forward(self, a):
+            x = torch.add(a, 1)
+            x = torch.add(x, 1)
+            pipe_split()
+            x = torch.add(x, 1)
+            x = torch.add(x, 1)
+            return x
+
+    torchdynamo.allow_in_graph(pipe_split)
+    ec = ExampleCode()
+    ec(torch.randn(10))
+    ec(torch.randn(10))
+
+    """
+    class ExampleCode(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+            self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+            self.lin = torch.nn.Linear(d_hid, d_hid)
+            self.register_buffer("buffer", torch.randn(bs + 100, d_hid))
+
+        def forward(self, x):
+            x = torch.mm(x, self.mm_param)
+            skip_connection = x
+            x = torch.relu(x)
+            pipe_split()
+            x = torch.mm(x, self.mm_param) + self.buffer[: x.shape[0]]
+            x = self.lin(x)
+            pipe_split()
+            x = torch.relu(x)
+            x = x + skip_connection
+            x = torch.mm(x, self.mm_param2)
+            x = self.lin(x)
+            pipe_split()
+            x = torch.relu(x)
+            return {"out": x}
+    """
+
+    """
+    ec = ExampleCode()
+    ec.to(args.device)
+    ec_input = torch.randn(bs, d_hid, device=args.device)
+    ec(ec_input)
+
+    ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
+    print(ec_pipe.split_gm)
+
+    args_chunk_spec = (TensorChunkSpec(0),)
+    kwargs_chunk_spec: Dict = {}
+    output_chunk_spec = {"out": TensorChunkSpec(0)}
+
+    pipe_driver: PipelineDriverBase = schedules[args.schedule](
+        ec_pipe,
+        5,
+        args_chunk_spec,
+        kwargs_chunk_spec,
+        output_chunk_spec,
+        args.world_size,
+        _debug_mask_minibatches=True,
+        _record_mem_dumps=bool(args.record_mem_dumps),
+        checkpoint=bool(args.checkpoint),
+    )
+
+    # # Warm up and correctness runs
+    out = pipe_driver(ec_input)
+    ref_out = ec_pipe(ec_input)
+
+    # run with different chunk size to exercise microbatch and scheduling components
+    pipe_driver.chunks = 1
+    pipe_driver(ec_input)
+    pipe_driver.chunks = 100
+    pipe_driver(ec_input)
+
+    if CHECK_NUMERIC_EQUIVALENCE:
+        torch.testing.assert_close(out["out"], ref_out["out"])
+        print(
+            f'equivalence test passed {torch.sum(out["out"])} ref {torch.sum(ref_out["out"])}'
+        )
+
+    # # Profiling runs
+    with torch.autograd.profiler_legacy.profile(
+        enabled=PROFILING_ENABLED
+    ) as prof:
+        pipe_driver.chunks = 5
+        out = pipe_driver(ec_input)
+        ref_out = ec_pipe(ec_input)
+        print(
+            f'profiling run completed {torch.sum(out["out"])} ref {torch.sum(ref_out["out"])}'
+        )
+    if PROFILING_ENABLED:
+        prof.export_chrome_trace(
+            f"{os.path.splitext(os.path.basename(__file__))[0]}.json"
+        )
+    """
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size", type=int, default=int(os.getenv("WORLD_SIZE", 4))
+    )
+    parser.add_argument("--rank", type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument(
+        "--master_addr", type=str, default=os.getenv("MASTER_ADDR", "localhost")
+    )
+    parser.add_argument(
+        "--master_port", type=str, default=os.getenv("MASTER_PORT", "29500")
+    )
+    parser.add_argument(
+        "-s",
+        "--schedule",
+        type=str,
+        default=list(schedules.keys())[0],
+        choices=schedules.keys(),
+    )
+    parser.add_argument(
+        "--replicate", type=int, default=int(os.getenv("REPLICATE", "0"))
+    )
+    parser.add_argument(
+        "--cuda", type=int, default=int(torch.cuda.is_available())
+    )
+    parser.add_argument(
+        "--record_mem_dumps", type=int, default=0, choices=[0, 1]
+    )
+    parser.add_argument("--checkpoint", type=int, default=0, choices=[0, 1])
+    args = parser.parse_args(args)
+
+    # Interleaved 1F1B uses less ranks than number of stages
+    if args.schedule == "Interleaved1F1B":
+        args.world_size = 2
+
+    # run_pippy(run_master, args)
+    run_master(0, args)
+
+
+if __name__ == "__main__":
+    main()
+
+
+class LocalTestForwardTest(unittest.TestCase):
+    def test_forward(self):
+        import random
+
+        port = random.randint(29500, 30000)
+        args = [
+            "--cuda",
+            os.getenv("USE_CUDA", "0"),
+            "--master_port",
+            str(port),
+        ]
+        main(args)


### PR DESCRIPTION
### Implementation:

1. Dynamo interception +
2. PiPPy compilation +
3. PiPPy distributed runtime

### Test:
```
python pippy_dynamo.py
```

### Output:
```
[PiPPy] World size: 4, DP group size: 1, PP group size: 4
WARNING > Module of stage 3 has no parameter or buffer, cannot figure out device. Setting it to cpu
WARNING > Module of stage 3 has no parameter or buffer, cannot figure out device. Setting it to cpu
rank = 2 host/pid/device = train-st-p3dn24xlarge-1/16644/cuda:2
rank = 3 host/pid/device = train-st-p3dn24xlarge-1/16645/cuda:3
rank = 1 host/pid/device = train-st-p3dn24xlarge-1/16643/cuda:1
rank = 0 host/pid/device = train-st-p3dn24xlarge-1/16642/cuda:0
REPLICATE config: 0 -> MultiUseParameterConfig.TRANSMIT
Using schedule: FillDrain

============= my_pippy_compiler() called with FX graph =============
opcode         name             target                                                   args                                   kwargs
-------------  ---------------  -------------------------------------------------------  -------------------------------------  --------
placeholder    x                x                                                        ()                                     {}
get_attr       self_mm_param    self_mm_param                                            ()                                     {}
call_function  mm               <built-in method mm of type object at 0x7fe1aa6d9b60>    (x, self_mm_param)                     {}
call_function  relu             <built-in method relu of type object at 0x7fe1aa6d9b60>  (mm,)                                  {}
call_function  pipe_split       <function pipe_split at 0x7fe0cfeb7c10>                  ()                                     {}
get_attr       self_mm_param_1  self_mm_param                                            ()                                     {}
call_function  mm_1             <built-in method mm of type object at 0x7fe1aa6d9b60>    (relu, self_mm_param_1)                {}
get_attr       self_buffer      self_buffer                                              ()                                     {}
call_function  getitem          <built-in function getitem>                              (self_buffer, slice(None, 503, None))  {}
call_function  add              <built-in function add>                                  (mm_1, getitem)                        {}
call_module    self_lin         self_lin                                                 (add,)                                 {}
call_function  pipe_split_1     <function pipe_split at 0x7fe0cfeb7c10>                  ()                                     {}
call_function  relu_1           <built-in method relu of type object at 0x7fe1aa6d9b60>  (self_lin,)                            {}
call_function  add_1            <built-in function add>                                  (relu_1, mm)                           {}
get_attr       self_mm_param2   self_mm_param2                                           ()                                     {}
call_function  mm_2             <built-in method mm of type object at 0x7fe1aa6d9b60>    (add_1, self_mm_param2)                {}
call_module    self_lin_1       self_lin                                                 (mm_2,)                                {}
call_function  pipe_split_2     <function pipe_split at 0x7fe0cfeb7c10>                  ()                                     {}
call_function  relu_2           <built-in method relu of type object at 0x7fe1aa6d9b60>  (self_lin_1,)                          {}
output         output           output                                                   ((relu_2,),)                           {}

======= GraphModule after Auto-split =======
GraphModule(
  (submod_0): GraphModule()
  (submod_1): GraphModule(
    (self_lin): Linear(in_features=512, out_features=512, bias=True)
  )
  (submod_2): GraphModule(
    (self_lin): Linear(in_features=512, out_features=512, bias=True)
  )
  (submod_3): GraphModule()
)



def forward(self, x : torch.Tensor):
    submod_0 = self.submod_0(x);  x = None
    getitem_2 = submod_0[2]
    getitem = submod_0[0]
    getitem_1 = submod_0[1];  submod_0 = None
    submod_1 = self.submod_1(getitem, getitem_2);  getitem = getitem_2 = None
    submod_2 = self.submod_2(submod_1, getitem_1);  submod_1 = getitem_1 = None
    submod_3 = self.submod_3(submod_2);  submod_2 = None
    return (submod_3,)
    
# To see more debug info, please use `graph_module.print_readable()`

======= Child module 0 =======
GraphModule()



def forward(self, x):
    moved_self_mm_param = self.moved_self_mm_param
    mm = torch.mm(x, moved_self_mm_param);  x = None
    relu = torch.relu(mm)
    return (relu, mm, moved_self_mm_param)
    
# To see more debug info, please use `graph_module.print_readable()`

======= Child module 1 =======
GraphModule(
  (self_lin): Linear(in_features=512, out_features=512, bias=True)
)



def forward(self, relu, self_mm_param):
    moved_self_buffer = self.moved_self_buffer
    mm = torch.mm(relu, self_mm_param);  relu = self_mm_param = None
    getitem = moved_self_buffer[slice(None, 503, None)];  moved_self_buffer = None
    add = mm + getitem;  mm = getitem = None
    self_lin = self.self_lin(add);  add = None
    return self_lin
    
# To see more debug info, please use `graph_module.print_readable()`

======= Child module 2 =======
GraphModule(
  (self_lin): Linear(in_features=512, out_features=512, bias=True)
)



def forward(self, self_lin, mm):
    moved_self_mm_param2 = self.moved_self_mm_param2
    relu = torch.relu(self_lin);  self_lin = None
    add = relu + mm;  relu = mm = None
    mm_1 = torch.mm(add, moved_self_mm_param2);  add = moved_self_mm_param2 = None
    self_lin_1 = self.self_lin(mm_1);  mm_1 = None
    return self_lin_1
    
# To see more debug info, please use `graph_module.print_readable()`

======= Child module 3 =======
GraphModule()



def forward(self, self_lin_1):
    relu = torch.relu(self_lin_1);  self_lin_1 = None
    return relu
    
# To see more debug info, please use `graph_module.print_readable()`

======= Runtime tests =======
equivalence test passed 215296752.0 ref 215296752.0
profiling run completed 215296752.0 ref 215296752.0
```