### PR TITLE
Update FSDP extension type annotation

### DIFF
--- a/spmd/tensor/parallel/fsdp.py
+++ b/spmd/tensor/parallel/fsdp.py
@@ -347,7 +347,7 @@ try:
         def pre_load_state_dict_transform(
             self,
             tensor: torch.Tensor,
-        ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+        ) -> Tuple[torch.Tensor, List[Shard]]:
             return _pre_load_state_dict(tensor)  # type: ignore
 
     _set_fsdp_extensions(DTensorExtensions())


### PR DESCRIPTION
The PR https://github.com/pytorch/pytorch/pull/86272 updated the type annotation for some of FSDP extensions, which is leading to some lint errors:
```
spmd/tensor/parallel/fsdp.py:347:8 Inconsistent override [15]: `spmd.tensor.parallel.fsdp.DTensorExtensions.pre_load_state_dict_transform` overrides method defined in `FSDPExtensions` inconsistently. Returned type `Tuple[torch._tensor.Tensor, List[torch._tensor.Tensor]]` is not a subtype of the overridden return `Tuple[torch._tensor.Tensor, List[dist._shard.sharded_tensor.shard.Shard]]`.
spmd/tensor/parallel/fsdp.py:347: error: Return type "Tuple[Tensor, List[Tensor]]" of "pre_load_state_dict_transform" incompatible with return type "Tuple[Tensor, List[Shard]]" in supertype "FSDPExtensions"
```
This PR updates the type annotation to match the one in `pytorch/master`.

~Is there a way to run the lint check manually to make sure this PR fixes everything?~ It looks like it ran in CI.