### PR TITLE
Use empty instead of zeros

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -922,7 +922,7 @@ class PipeStageExecutor(EventRecorder):
         if "tensor_meta" in value_ref_arg.meta:
             tm = value_ref_arg.meta["tensor_meta"]
             use_c10d = True
-            recv_buff = torch.zeros(
+            recv_buff = torch.empty(
                 tm.shape, dtype=tm.dtype, device=self.device
             )
 


### PR DESCRIPTION
For potentially higher performance as `torch.empty` returns a tensor filled with **uninitialized** data.
Thanks @pbelevich for spotting it!