### PR TITLE
[spmd] pin pt version

### DIFF
--- a/spmd/requirements.txt
+++ b/spmd/requirements.txt
@@ -5,10 +5,10 @@ pyyaml
 
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch >= 1.14.0.dev0; sys_platform == "darwin"
+torch >= 1.14.0.dev0, <= 1.14.0dev20221021; sys_platform == "darwin"
 
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 --extra-index-url https://download.pytorch.org/whl/nightly/cu116
-torch >= 1.14.0.dev0; sys_platform == "linux"
+torch >= 1.14.0.dev0, <= 1.14.0dev20221021; sys_platform == "linux"
 


### PR DESCRIPTION
A recent change of c10d.ReduceOp crashes deepcopy of it, pin pt version temporarily to fix CI.
see https://github.com/pytorch/pytorch/pull/87303#discussion_r1002879700