### PR TITLE
[dtensor] use RedOpType and unpin pt version

### DIFF
--- a/spmd/requirements.txt
+++ b/spmd/requirements.txt
@@ -5,10 +5,10 @@ pyyaml
 
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch >= 1.14.0.dev0, <= 1.14.0dev20221021; sys_platform == "darwin"
+torch >= 1.14.0.dev0; sys_platform == "darwin"
 
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 --extra-index-url https://download.pytorch.org/whl/nightly/cu116
-torch >= 1.14.0.dev0, <= 1.14.0dev20221021; sys_platform == "linux"
+torch >= 1.14.0.dev0; sys_platform == "linux"
 

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -202,10 +202,8 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             layout=local_tensor.layout,
             requires_grad=requires_grad,
         )
-        # deepcopy and set spec, data should be handled
-        # by __init__ or from_local instead.
         r._spec = DTensorSpec(
-            device_mesh, copy.deepcopy(placements), shape=r.size()
+            device_mesh, placements, shape=r.size()
         )
         # detach local tensor from autograd graph as we initialize the
         # distributed tensor and autograd will be working on top of

--- a/spmd/tensor/api.py
+++ b/spmd/tensor/api.py
@@ -202,8 +202,9 @@ class DTensor(torch.Tensor):  # pyre-ignore[13]: pyre is bad at __new__
             layout=local_tensor.layout,
             requires_grad=requires_grad,
         )
+        # deepcopy and set spec
         r._spec = DTensorSpec(
-            device_mesh, placements, shape=r.size()
+            device_mesh, copy.deepcopy(placements), shape=r.size()
         )
         # detach local tensor from autograd graph as we initialize the
         # distributed tensor and autograd will be working on top of

--- a/spmd/tensor/device_mesh.py
+++ b/spmd/tensor/device_mesh.py
@@ -368,7 +368,7 @@ class DeviceMesh(object):
     def all_reduce(
         self,
         tensor: torch.Tensor,
-        op: ReduceOp = ReduceOp.SUM,  # type: ignore
+        op: ReduceOp.RedOpType = ReduceOp.RedOpType.SUM,  # type: ignore
         mesh_dim: int = 0,
         async_op: bool = False,
     ) -> Optional[Work]:
@@ -393,7 +393,7 @@ class DeviceMesh(object):
         self,
         output: torch.Tensor,
         input_list: List[torch.Tensor],
-        op: ReduceOp = ReduceOp.SUM,  # type: ignore
+        op: ReduceOp.RedOpType = ReduceOp.RedOpType.SUM,  # type: ignore
         mesh_dim: int = 0,
         async_op: bool = False,
     ) -> Optional[Work]:

--- a/spmd/tensor/placement_types.py
+++ b/spmd/tensor/placement_types.py
@@ -214,7 +214,7 @@ class Replicate(Placement):
 @dataclass
 class _Partial(Placement):
     # partial placement with reduce op
-    reduce_op: c10d.ReduceOp = c10d.ReduceOp.SUM  # type: ignore
+    reduce_op: c10d.ReduceOp.RedOpType = c10d.ReduceOp.RedOpType.SUM  # type: ignore
 
 
 # used internally to propagate the placements

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -2,8 +2,6 @@
 import itertools
 import torch
 
-from torch.distributed.distributed_c10d import ReduceOp
-
 from torch.testing._internal.common_utils import run_tests
 
 from spmd.testing.common_utils import (  # type: ignore

--- a/test/spmd/tensor/test_redistribute.py
+++ b/test/spmd/tensor/test_redistribute.py
@@ -129,7 +129,7 @@ class RedistributeTest(DistTensorTestBase):
         partial_local = torch.randn(
             12, 3, device=self.device_type, requires_grad=True
         )
-        partial_spec = [_Partial(ReduceOp.SUM)]
+        partial_spec = [_Partial()]
         replica_spec = [Replicate()]
         # test partial -> replicate, which trigger all_reduce
         partial_tensor = DTensor.from_local(
@@ -154,7 +154,7 @@ class RedistributeTest(DistTensorTestBase):
         local_tensor = torch.randn(
             12, 3, device=self.device_type, requires_grad=True
         )
-        partial_spec = _Partial(ReduceOp.SUM)
+        partial_spec = _Partial()
         replica_spec = Replicate()
         # 1) test replicate -> partial forward
         replica_tensor = distribute_tensor(
@@ -212,7 +212,7 @@ class RedistributeTest(DistTensorTestBase):
     @with_comms
     def test_partial_to_shard(self):
         device_mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
-        partial_spec = [_Partial(ReduceOp.SUM)]
+        partial_spec = [_Partial()]
 
         input_sizes_and_shard_dim = [
             ((self.world_size * 3, 3), 0),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #581
* #582

use RedOpType instead to avoid deepcopy failure of c10d.ReduceOp