### PR TITLE
[dtensor] fix a corner case in pointwise rule

### DIFF
--- a/spmd/tensor/ops/common_rules.py
+++ b/spmd/tensor/ops/common_rules.py
@@ -234,7 +234,7 @@ def pointwise_rule(
     input_specs = op_schema.args_spec
     max_dim = max(input.ndim for input in input_specs)
     dimchars = []
-    dimchar_singleton_counter: Dict[str, int] = {}
+    singleton_counter: List[int] = [0] * max_dim
     for input in input_specs:
         start_dim = max_dim - input.ndim
         p = alphabet[start_dim:max_dim]
@@ -245,20 +245,22 @@ def pointwise_rule(
         # the non-singleton dimension, so that sharding propagation
         # should just ignore the singleton dimension.
         if len(input_specs) > 1:
-            for i, dim_length in enumerate(input.shape):
-                if dim_length == 1:
+            for i in range(max_dim):
+                if i < start_dim:
+                    # treat the leading miss dim chars as singleton
+                    singleton_counter[i] += 1
+                elif input.shape[i - start_dim] == 1:
                     # mark singleton dim char as a special "1" in einop rule
-                    dimchar_singleton_counter[p[i]] = (
-                        dimchar_singleton_counter.get(p[i], 0) + 1
-                    )
+                    singleton_counter[i] += 1
                     p = _replace_char_in_str(p, "1", i)
+
         dimchars.append(p)
     out_dimchars = alphabet[:max_dim]
     # check if we replace the all inputs dim char with singleton dimension,
     # if we replace all inputs, we also need to replace the output dimension.
     for output_dim_idx in range(len(out_dimchars)):
         out_dimchar = out_dimchars[output_dim_idx]
-        if dimchar_singleton_counter.get(out_dimchar, 0) == len(input_specs):
+        if singleton_counter[output_dim_idx] == len(input_specs):
             out_dimchars = _replace_char_in_str(
                 out_dimchars, "1", output_dim_idx
             )

--- a/spmd/tensor/ops/common_rules.py
+++ b/spmd/tensor/ops/common_rules.py
@@ -252,7 +252,7 @@ def pointwise_rule(
                 elif input.shape[i - start_dim] == 1:
                     # mark singleton dim char as a special "1" in einop rule
                     singleton_counter[i] += 1
-                    p = _replace_char_in_str(p, "1", i)
+                    p = _replace_char_in_str(p, "1", (i - start_dim))
 
         dimchars.append(p)
     out_dimchars = alphabet[:max_dim]

--- a/test/spmd/tensor/test_common_rules.py
+++ b/test/spmd/tensor/test_common_rules.py
@@ -278,6 +278,32 @@ class CommonRulesTest(DistTensorTestBase):
             )
 
     @with_comms
+    def test_pointwise_rules_broadcasting(self):
+        mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+
+        func_schema = self.parse_schema(
+            "where.self(Tensor condition, Tensor self, Tensor other) -> Tensor"
+        )
+        inp1, inp2, inp3 = [0], [], [-1, -1]
+        condition = DTensorSpec.from_dim_map(
+            mesh, inp1, [], shape=torch.Size([8])
+        )
+        self_tensor = DTensorSpec.from_dim_map(
+            mesh, inp2, [], shape=torch.Size([])
+        )
+        other_tensor = DTensorSpec.from_dim_map(
+            mesh, inp3, [], shape=torch.Size([1, 1])
+        )
+        # propagate point-wise sharding with broadcasting
+        output_sharding = pointwise_rule(
+            OpSchema(func_schema, (condition, self_tensor, other_tensor), {})
+        )
+        output_spec = output_sharding.output_spec
+        self.assertIsNotNone(output_spec)
+        self.assertEqual(output_spec.dim_map, [-1, 0])
+        self.assertEqual(output_spec.shape, [1, 8])
+
+    @with_comms
     def test_pointwise_rules_suggestion(self):
         mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #581
* __->__ #582

This fixes a corner case in the pointwise rule when handling the
singleton dims, where if it should not be "b, ,11->ab", and instead
it should be "b, ,11->1b"