### PR TITLE
Fix data race when using socket

### DIFF
--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -904,7 +904,8 @@ class PipeStageExecutor(EventRecorder):
 
         # Instead of return value let's do a send call
         if use_c10d:
-            if self.device.type == "cpu":
+            if torch.distributed.get_backend() == "gloo":
+                # Gloo error out with isend, use send instead
                 torch.distributed.send(value, caller_stage)
             else:
                 torch.distributed.isend(value, caller_stage)
@@ -935,7 +936,8 @@ class PipeStageExecutor(EventRecorder):
 
         if use_c10d:
             work = None
-            if self.device.type == "cpu":
+            if torch.distributed.get_backend() == "gloo":
+                # Gloo error out with irecv, use recv instead
                 torch.distributed.recv(recv_buff, callee_stage)
             else:
                 work = torch.distributed.irecv(recv_buff, callee_stage)
@@ -947,9 +949,13 @@ class PipeStageExecutor(EventRecorder):
             )
             if use_c10d:
                 if work:
+                    # For CUDA, wait() only ensure collective enqueue and compute-comm stream dependency
                     work.wait()
+                    # Need to use is_completed() to sync back to CPU
                     while not work.is_completed():
                         pass
+                    # TODO: move compute-comm dependency to be entirely stream based, rather than based on CPU
+                    # conditional variable, see `update_run_list` below
                 self.rank_worker.update_run_list(
                     runlist_key, arg_idx, recv_buff
                 )


### PR DESCRIPTION
### Before fix:
```
NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 python pippy_dynamo.py --cuda=1
```
would fail the equivalence test. (`NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1` would force NCCL to use socket instead of NVLink.)

### Root cause:
This is due to PiPPy still relying on CPU to perform data synchronization, but we didn't check if the collective has completed from CPU's view.

### Solution:
Added `work.is_completed()` for CPU to confirm collective completion before putting result into ready list.

### TODO:
Move compute-comm dependency to be entirely stream based, rather than based on CPU conditional variable