### PR TITLE
Extend c10d support to non-Dynamo cases and support dynamic shapes across batches

### DIFF
--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -22,7 +22,6 @@ from pippy.PipelineDriver import (
     PipelineDriver1F1B,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.fx.passes import shape_prop
 from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True

--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -224,6 +224,7 @@ def transform_into_pipeline(
         _debug_mask_minibatches=False,
         _record_mem_dumps=bool(args.record_mem_dumps),
         checkpoint=bool(args.checkpoint) if args.train else False,
+        use_c10d = False if args.train else True,   # Safe to use c10d in inference mode
     )
     return pipe_driver
 

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1874,7 +1874,9 @@ class RemoteInterpreter(pippy.fx.Interpreter, EventRecorder):
         for node in self.node_list:
             logging.debug(f"Node: {node.name}, outputs: ")
             if "tensor_meta" in node.meta:
-                if isinstance(node.meta["tensor_meta"], shape_prop.TensorMetadata):
+                if isinstance(
+                    node.meta["tensor_meta"], shape_prop.TensorMetadata
+                ):
                     logging.debug(f"- {node.meta['tensor_meta']}")
                 else:
                     # Multiple output tensors

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1871,11 +1871,11 @@ class RemoteInterpreter(pippy.fx.Interpreter, EventRecorder):
         sp.propagate(*example_input)
         for node in self.node_list:
             logging.debug(f"Node: {node.name}, outputs: ")
-            if isinstance(node.meta['tensor_meta'], shape_prop.TensorMetadata):
+            if isinstance(node.meta["tensor_meta"], shape_prop.TensorMetadata):
                 logging.debug(f"- {node.meta['tensor_meta']}")
             else:
                 # Multiple output tensors
-                for t_meta in node.meta['tensor_meta']:
+                for t_meta in node.meta["tensor_meta"]:
                     logging.debug(f"- {t_meta}")
 
 

--- a/pippy/__init__.py
+++ b/pippy/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import logging
+import os
 from pippy.IR import (
     PipeSequential,
     LossWrapper,
@@ -27,3 +29,10 @@ __all__ = [
     "split_into_equal_size",
     "split_on_size_threshold",
 ]
+
+pippy_debug = os.environ.get("PIPPY_DEBUG", "OFF")
+
+if pippy_debug == "INFO":
+    logging.getLogger().setLevel(logging.INFO)
+elif pippy_debug == "DEBUG":
+    logging.getLogger().setLevel(logging.DEBUG)

--- a/pippy/__init__.py
+++ b/pippy/__init__.py
@@ -1,6 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
-import logging
-import os
 from pippy.IR import (
     PipeSequential,
     LossWrapper,
@@ -29,10 +27,3 @@ __all__ = [
     "split_into_equal_size",
     "split_on_size_threshold",
 ]
-
-pippy_debug = os.environ.get("PIPPY_DEBUG", "OFF")
-
-if pippy_debug == "INFO":
-    logging.getLogger().setLevel(logging.INFO)
-elif pippy_debug == "DEBUG":
-    logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Note: dynamic shape is supported across **batches** (not **microbatches** yet).

### Implementation:
- Moved shape propagation from Dynamo's compile function to PiPPy's `RemoteInterpreter`.
- Added `use_c10d` knob to `PipelineDriver` for user to turn this feature on/off

### Test of dynamic shape:

- 1st iteration:
```
bs = 503
ec_input = torch.randn(bs, d_hid, device=args.device)
```
```
DEBUG:root:Node: x, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=False, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_0, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:- TensorMetadata(shape=torch.Size([512, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem_2, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([512, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem_1, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_1, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_2, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_3, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: output, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([503, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
```

- 2nd iteration:
```
bs = bs + 10
ec_input = torch.randn(bs, d_hid, device=args.device)
```
```
DEBUG:root:Node: x, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=False, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_0, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:- TensorMetadata(shape=torch.Size([512, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem_2, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([512, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: getitem_1, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_1, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_2, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: submod_3, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
DEBUG:root:Node: output, outputs: 
DEBUG:root:- TensorMetadata(shape=torch.Size([513, 512]), dtype=torch.float32, requires_grad=True, stride=(512, 1), memory_format=torch.contiguous_format, is_quantized=False, qparams={})
```

### Test with T5:
Inference only:
```
$ cd examples/hf/t5
$ python pippy_t5.py --train 0 --world_size=8 --pp_group_size=8
```