### PR TITLE
[TP][Easy] Fix 2d parallel integration code and add more test

### DIFF
--- a/spmd/tensor/parallel/fsdp.py
+++ b/spmd/tensor/parallel/fsdp.py
@@ -1,5 +1,4 @@
 import warnings
-import functools
 import copy
 from typing import List, NamedTuple, Optional, Tuple, cast
 

--- a/spmd/tensor/parallel/fsdp.py
+++ b/spmd/tensor/parallel/fsdp.py
@@ -206,21 +206,12 @@ def _unflatten_tensor(
             process_group=cast(dist.ProcessGroup, sharding_info.process_group),
         )
     else:
-
-        def _dt_gradient_hook(
-            param: DistributedTensor, grad: DistributedTensor
-        ) -> None:
-            param.grad = grad
-            param._local_tensor.grad = grad._local_tensor
-
-        result = dtensor = DistributedTensor.from_local(
+        result = DistributedTensor.from_local(
             tensor,
             device_mesh=sharding_info.device_mesh,
             placements=sharding_info.placements,
             run_check=False,
         )
-        if dtensor.requires_grad:
-            dtensor.register_hook(functools.partial(_dt_gradient_hook, dtensor))
 
     _set_fsdp_flattened(result)
     return result

--- a/test/spmd/tensor/parallel/test_2d_parallel.py
+++ b/test/spmd/tensor/parallel/test_2d_parallel.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Any
 
 

--- a/test/spmd/tensor/parallel/test_2d_parallel.py
+++ b/test/spmd/tensor/parallel/test_2d_parallel.py
@@ -75,10 +75,6 @@ def _replicate_input_tensor(
     return module
 
 
-def _gradient_hook(param, grad):
-    param._local_tensor.grad = grad._local_tensor
-
-
 def shard_module(m, pg):
     start_idx = distributed_c10d.get_global_rank(pg, 0)
     device_mesh = DeviceMesh(
@@ -101,14 +97,6 @@ def shard_module(m, pg):
     )
     m = _replicate_input_tensor(m, device_mesh, replicate)
     m.net2 = _aggregate_local_tensor(m.net2)
-    m.net1.weight.register_hook(
-        functools.partial(_gradient_hook, m.net1.weight)
-    )
-    m.net2.weight.register_hook(
-        functools.partial(_gradient_hook, m.net2.weight)
-    )
-    m.net1.bias.register_hook(functools.partial(_gradient_hook, m.net1.bias))
-    m.net2.bias.register_hook(functools.partial(_gradient_hook, m.net2.bias))
 
 
 def _shard_wrap_module(module, module_shard, fsdp_wrap, tp_pg, fsdp_pg):
@@ -163,11 +151,11 @@ def is_nested_tensor(val: Any) -> bool:
 class Test2dParallelIntegration(DistTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(4)
-    def test_2d_fsdp_integration(self) -> None:
+    def test_2d_fsdp_integration_functionality(self) -> None:
         if not is_available():
             self.skipTest("FSDP 2d parallel integration not available")
 
-        model_tp, tp_pg, dp_pg = init_model()
+        model_tp = init_model()[0]
 
         with FSDP.state_dict_type(model_tp, StateDictType.SHARDED_STATE_DICT):
             state_dict = model_tp.state_dict()
@@ -193,6 +181,33 @@ class Test2dParallelIntegration(DistTensorTestBase):
         self.assertFalse(
             is_nested_tensor(optim_state["state"]["net3.bias"]["exp_avg"])
         )
+
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    def test_2d_fsdp_integration_correctness(self) -> None:
+        if not is_available():
+            self.skipTest("FSDP 2d parallel integration not available")
+        torch.manual_seed(0)
+        model = SimpleModel().cuda(self.rank)
+        model = FSDP(model)
+        torch.manual_seed(0)
+        model_2d, _, dp_pg = init_model()
+
+        optim = torch.optim.Adam(model.parameters(), lr=0.0001)
+        optim_2d = torch.optim.Adam(model_2d.parameters(), lr=0.0001)
+
+        for i in range(5):
+            # Ensure all input across TP ranks are same.
+            torch.manual_seed(i + dist.get_rank(dp_pg))
+            input = torch.rand(4, 5).cuda(self.rank)
+            output = model(input)
+            output_2d = model_2d(input)
+            self.assertEqual(output, output_2d)
+            output.sum().backward()
+            output_2d.sum().backward()
+            optim.step()
+            optim_2d.step()
+            self.assertEqual(model(input), model_2d(input))
 
 
 if __name__ == "__main__":

--- a/test/spmd/tensor/parallel/test_tp_examples.py
+++ b/test/spmd/tensor/parallel/test_tp_examples.py
@@ -46,10 +46,6 @@ def _aggregate_local_tensor(module: torch.nn.Module) -> torch.nn.Module:
     return module
 
 
-def _gradient_hook(param, grad):
-    param._local_tensor.grad = grad._local_tensor
-
-
 def shard_mlp(m, device_type, tp_size):
     start_idx = 0
     device_mesh = DeviceMesh(
@@ -75,9 +71,6 @@ def shard_mlp(m, device_type, tp_size):
                 )
                 module.register_parameter("weight", sharded_weight)
                 module.register_parameter("bias", sharded_bias)
-                module.weight.register_hook(
-                    functools.partial(_gradient_hook, module.weight)
-                )
             elif name == "net2":
                 sharded_weight = nn.Parameter(
                     distribute_tensor(
@@ -150,8 +143,6 @@ class DistTensorParallelExampleTest(DistTensorTestBase):
 
         output.sum().backward()
         output_tp.sum().backward()
-        # This is for FSDP + TP integration.
-        self.assertTrue(model_tp.net1.weight._local_tensor.grad is not None)
 
         device_mesh = model_tp.net1.weight.device_mesh
         replicate = [Replicate()] * device_mesh.ndim

--- a/test/spmd/tensor/parallel/test_tp_examples.py
+++ b/test/spmd/tensor/parallel/test_tp_examples.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 import torch.nn as nn
-import functools
 from torch.testing._internal.common_utils import run_tests
 from spmd.testing.common_utils import DistTensorTestBase, with_comms, NUM_DEVICES, skip_unless_torch_gpu  # type: ignore
 from spmd import (


### PR DESCRIPTION
We found that TP has loads of DTensor not released and we need to call gc.collect() to get them releases. This is the root cause of ViT model training OOM. Upon further debugging, we have found that it's the gradient hook which causes the issue. And in this PR, we remove the gradient hook completely and add a new test which covers the correctness of 2D parallel by comparing the result from FSDP and 2D.