### PR TITLE
Use scikit-learn identifier instead of sklearn

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov numpy datasets evaluate sklearn sacrebleu
+          pip install flake8 pytest pytest-cov numpy datasets evaluate scikit-learn sacrebleu
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Install pavel's huggingface fork
         run: pip install git+https://github.com/huggingface/transformers.git@main sentencepiece six sacremoses
@@ -157,7 +157,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov numpy datasets evaluate sklearn sacrebleu
+          pip install flake8 pytest pytest-cov numpy datasets evaluate scikit-learn sacrebleu
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Install pavel's huggingface fork
         run: pip install git+https://github.com/huggingface/transformers.git@main sentencepiece six sacremoses


### PR DESCRIPTION
Ref: https://scikit-learn.org/stable/install.html
Ref: https://towardsdatascience.com/scikit-learn-vs-sklearn-6944b9dc1736#:~:text=Essentially%2C%20sklearn%20is%20a%20dummy,not%20the%20actual%20package%20itself.

"it is recommended to install scikit-learn through pip using the scikit-learn identifier."

"Essentially, sklearn is a [dummy project on PyPi](https://pypi.org/project/sklearn/) that will in turn install scikit-learn."