### PR TITLE
Add --chunks option to T5 example

### DIFF
--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -273,7 +273,7 @@ def run_master(pp_ranks, args):
         pippy.utils.exclude_master : pippy.utils.exclude_master
         + number_of_workers
     ]
-    chunks = len(all_worker_ranks)
+    chunks = args.chunks or len(all_worker_ranks)
     bs = args.batch_size * chunks
     seq_length = args.seq_length
 
@@ -357,6 +357,7 @@ if __name__ == "__main__":
     parser.add_argument("--model_config", type=str, default=model_config)
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--batches", type=int, default=1)
+    parser.add_argument("--chunks", type=int, default=None)
     parser.add_argument("--seq_length", type=int, default=16)
 
     parser.add_argument("--num_encoder_layers", type=int, default=None)


### PR DESCRIPTION
To support inference of one chunk only, for example.