### PR TITLE
[PT-D] Add Tensor Parallel _prepare_output component functions

### DIFF
--- a/spmd/tensor/parallel/__init__.py
+++ b/spmd/tensor/parallel/__init__.py
@@ -8,3 +8,9 @@ from spmd.tensor.parallel.api import (
     replicate_input,
     replicate_output,
 )
+
+from spmd.tensor.parallel.style import (
+    make_output_shard_1d,
+    make_output_replicate_1d,
+    make_output_tensor,
+)

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -1,11 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
-from typing import Union, Optional
+from typing import Optional
 from spmd.tensor import DTensor, Shard, Replicate, DeviceMesh
 from spmd.tensor.parallel.utils import _prepare_output_validate
 
 
-@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_shard_1d(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None, dim: int = 0
 ) -> DTensor:
@@ -25,7 +25,7 @@ def make_output_shard_1d(
     return output.redistribute(device_mesh, [Shard(dim)])
 
 
-@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_replicate_1d(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None,
 ) -> DTensor:
@@ -44,7 +44,7 @@ def make_output_replicate_1d(
     return output.redistribute(device_mesh, [Replicate()])
 
 
-@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_tensor(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None
 ) -> torch.Tensor:

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import torch
+from typing import Union, Optional
+from spmd.tensor import DTensor, Shard, Replicate, DeviceMesh
+from spmd.tensor.parallel.utils import _prepare_output_validate
+
+
+@_prepare_output_validate
+def make_output_shard_1d(
+    output: DTensor, device_mesh: Optional[DeviceMesh] = None, dim: int = 0
+) -> DTensor:
+    """
+    Convert Output DTensor to a sharded DTensor. This will be used in ParallelStyle.
+    Args:
+        output (DTensor): output of module to be converted.
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to shard the output DTensor. 
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a 
+            non-1D DeviceMesh is passed in. If no DeviceMesh is passed in, we will 
+            reuse the one from output DTensor.
+        dim (int): Sharding dim for output DTensor.
+    Return:
+        (DTensor): A DTensor sharded on the given dim.
+    """
+
+    return output.redistribute(device_mesh, [Shard(dim)])
+
+
+@_prepare_output_validate
+def make_output_replicate_1d(
+    output: Union[torch.Tensor, DTensor],
+    device_mesh: Optional[DeviceMesh] = None,
+) -> DTensor:
+    """
+    Convert Output DTensor to a replicated DTensor. This will be used in ParallelStyle.
+    Args:
+        output (DTensor): output of module to be converted.
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor. 
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D 
+            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the 
+            one from output DTensor.
+    Return:
+        (DTensor): A DTensor made repliacted.
+    """
+
+    return output.redistribute(device_mesh, [Replicate()])
+
+
+@_prepare_output_validate
+def make_output_tensor(
+    output: DTensor, device_mesh: Optional[DeviceMesh] = None
+) -> torch.Tensor:
+    """
+    Convert Output DTensor to a replicated DTensor first and then convert it to Tensor.
+    Args:
+        output (DTensor): output of module to be converted.
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor. 
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D 
+            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the 
+            one from output DTensor.
+    Return:
+        (torch.Tensor): A tensor converted from output DTensor.
+    """
+
+    return make_output_replicate_1d(output, device_mesh).to_local()

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -13,9 +13,9 @@ def make_output_shard_1d(
     Convert Output DTensor to a sharded DTensor. This will be used in ParallelStyle.
     Args:
         output (DTensor): output of module to be converted.
-        device_mesh (Optional[DeviceMesh]): DeviceMesh to shard the output DTensor. 
-            This needs to be a 1D DeviceMesh and we will throw exceptions if a 
-            non-1D DeviceMesh is passed in. If no DeviceMesh is passed in, we will 
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to shard the output DTensor.
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a
+            non-1D DeviceMesh is passed in. If no DeviceMesh is passed in, we will
             reuse the one from output DTensor.
         dim (int): Sharding dim for output DTensor.
     Return:
@@ -33,9 +33,9 @@ def make_output_replicate_1d(
     Convert Output DTensor to a replicated DTensor. This will be used in ParallelStyle.
     Args:
         output (DTensor): output of module to be converted.
-        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor. 
-            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D 
-            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the 
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor.
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D
+            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the
             one from output DTensor.
     Return:
         (DTensor): A DTensor made repliacted.
@@ -52,9 +52,9 @@ def make_output_tensor(
     Convert Output DTensor to a replicated DTensor first and then convert it to Tensor.
     Args:
         output (DTensor): output of module to be converted.
-        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor. 
-            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D 
-            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the 
+        device_mesh (Optional[DeviceMesh]): DeviceMesh to replicate the output DTensor.
+            This needs to be a 1D DeviceMesh and we will throw exceptions if a non-1D
+            DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the
             one from output DTensor.
     Return:
         (torch.Tensor): A tensor converted from output DTensor.

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -27,7 +27,7 @@ def make_output_shard_1d(
 
 @_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_output_replicate_1d(
-    output: DTensor, device_mesh: Optional[DeviceMesh] = None,
+    output: DTensor, device_mesh: Optional[DeviceMesh] = None
 ) -> DTensor:
     """
     Convert Output DTensor to a replicated DTensor. This will be used in ParallelStyle.

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -38,7 +38,7 @@ def make_output_replicate_1d(
             DeviceMesh is passed in. If no DeviceMesh is passed in, we will reuse the
             one from output DTensor.
     Return:
-        (DTensor): A DTensor made repliacted.
+        (DTensor): A DTensor made replicate.
     """
 
     return output.redistribute(device_mesh, [Replicate()])

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -5,7 +5,7 @@ from spmd.tensor import DTensor, Shard, Replicate, DeviceMesh
 from spmd.tensor.parallel.utils import _prepare_output_validate
 
 
-@_prepare_output_validate
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
 def make_output_shard_1d(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None, dim: int = 0
 ) -> DTensor:
@@ -25,10 +25,9 @@ def make_output_shard_1d(
     return output.redistribute(device_mesh, [Shard(dim)])
 
 
-@_prepare_output_validate
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
 def make_output_replicate_1d(
-    output: Union[torch.Tensor, DTensor],
-    device_mesh: Optional[DeviceMesh] = None,
+    output: DTensor, device_mesh: Optional[DeviceMesh] = None,
 ) -> DTensor:
     """
     Convert Output DTensor to a replicated DTensor. This will be used in ParallelStyle.
@@ -45,7 +44,7 @@ def make_output_replicate_1d(
     return output.redistribute(device_mesh, [Replicate()])
 
 
-@_prepare_output_validate
+@_prepare_output_validate  # type: ignore[arg-type] # pyre-ignore[1]
 def make_output_tensor(
     output: DTensor, device_mesh: Optional[DeviceMesh] = None
 ) -> torch.Tensor:
@@ -61,4 +60,6 @@ def make_output_tensor(
         (torch.Tensor): A tensor converted from output DTensor.
     """
 
-    return make_output_replicate_1d(output, device_mesh).to_local()
+    return make_output_replicate_1d(  # type: ignore[attr-defined]
+        output, device_mesh
+    ).to_local()  # type: ignore[call-arg]

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -1,0 +1,51 @@
+import functools
+
+import torch
+from spmd.tensor import DeviceMesh, DTensor
+from typing import Callable, Optional, Union
+
+
+def _prepare_output_validate(
+    _prepare_output_func: Callable[
+        [DTensor, Optional[DeviceMesh], Optional[int]],
+        Union[torch.Tensor, DTensor],
+    ]
+) -> Callable[
+    [DTensor, Optional[DeviceMesh], Optional[int]], Union[torch.Tensor, DTensor]
+]:
+    """
+    Inject common validation logics for _prepare_output funcs via this 
+    decorator, including verifying that output needs to be a DTensor 
+    and only 1D Device Mesh is passed in.
+    Example::
+        >>> @_prepare_output_validate
+        >>> def make_output_shard_1d(args, kwargs):
+        >>>   ...
+        >>>
+        >>> dt = distribute(tensor, device_mesh, [Shard(0)])
+        >>> make_output_shard_1d(dt, device_mesh, 1)
+        >>> # This will call '_prepare_output_validate' first
+    Args:
+        _prepare_output_func (Callable): The func we want to inject the 
+            validation into.
+    Return:
+        func (Callable): Same input func with validation logic added.
+    """
+
+    @functools.wraps(_prepare_output_func)
+    def wrapper(*args, **kwargs):
+        assert len(args) >= 2, "_prepare_output need at least two args."
+        output = args[0]
+        device_mesh = args[1]
+        assert isinstance(
+            output, DTensor
+        ), f"output of Tensor Parallel is actually {type(output)} not DTensor."
+        if device_mesh is None:
+            device_mesh = output.device_mesh
+
+        assert (
+            device_mesh.ndim == 1
+        ), f"{_prepare_output_func.__name__}: device mesh is not 1D"
+        return _prepare_output_func(*args, **kwargs)
+
+    return wrapper

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -33,7 +33,7 @@ def _prepare_output_validate(
 
     @functools.wraps(_prepare_output_func)
     def wrapper(*args, **kwargs):  # pyre-ignore[2, 3]
-        assert len(args) >= 1, "_prepare_output need at least one arg."
+        assert len(args) >= 1, "_prepare_output needs at least one arg."
         output = args[0]
         assert isinstance(
             output, DTensor

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -45,7 +45,7 @@ def _prepare_output_validate(
 
         assert (
             device_mesh.ndim == 1
-        ), f"{_prepare_output_func.__name__}: device mesh is not 1D"
+        ), f"device_mesh has dims {device_mesh.ndim} but expcted to be 1 for output."
         return _prepare_output_func(*args, **kwargs)
 
     return wrapper

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -33,7 +33,7 @@ def _prepare_output_validate(
     """
 
     @functools.wraps(_prepare_output_func)
-    def wrapper(*args, **kwargs): # pyre-ignore[2, 3]
+    def wrapper(*args, **kwargs):  # pyre-ignore[2, 3]
         assert len(args) >= 2, "_prepare_output need at least two args."
         output = args[0]
         device_mesh = args[1]

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -10,7 +10,7 @@ _Prepare_Output_Func_Type = Callable[
 
 
 def _prepare_output_validate(
-    _prepare_output_func: _Prepare_Output_Func_Type
+    _prepare_output_func: _Prepare_Output_Func_Type,
 ) -> _Prepare_Output_Func_Type:
     """
     Inject common validation logics for _prepare_output funcs via this

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -14,8 +14,8 @@ def _prepare_output_validate(
     [DTensor, Optional[DeviceMesh], Optional[int]], Union[torch.Tensor, DTensor]
 ]:
     """
-    Inject common validation logics for _prepare_output funcs via this 
-    decorator, including verifying that output needs to be a DTensor 
+    Inject common validation logics for _prepare_output funcs via this
+    decorator, including verifying that output needs to be a DTensor
     and only 1D Device Mesh is passed in.
     Example::
         >>> @_prepare_output_validate
@@ -26,7 +26,7 @@ def _prepare_output_validate(
         >>> make_output_shard_1d(dt, device_mesh, 1)
         >>> # This will call '_prepare_output_validate' first
     Args:
-        _prepare_output_func (Callable): The func we want to inject the 
+        _prepare_output_func (Callable): The func we want to inject the
             validation into.
     Return:
         func (Callable): Same input func with validation logic added.

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -33,7 +33,7 @@ def _prepare_output_validate(
     """
 
     @functools.wraps(_prepare_output_func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs): # pyre-ignore[2, 3]
         assert len(args) >= 2, "_prepare_output need at least two args."
         output = args[0]
         device_mesh = args[1]

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -3,7 +3,6 @@
 import torch
 from spmd.testing.common_dtensor import DTensorTestBase, with_comms
 from spmd.tensor import distribute_tensor, DeviceMesh, Shard, Replicate
-from spmd.tensor import distribute_tensor, DeviceMesh
 from spmd.tensor.parallel.style import (
     make_output_shard_1d,
     make_output_replicate_1d,

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -1,0 +1,86 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+from spmd.testing.common_dtensor import DTensorTestBase, with_comms
+from spmd.tensor import distribute_tensor, DeviceMesh, Shard, Replicate
+from spmd.tensor import distribute_tensor, DeviceMesh
+from spmd.tensor.parallel.style import (
+    make_output_shard_1d,
+    make_output_replicate_1d,
+    make_output_tensor,
+)
+
+
+class TensorParallelStyleTest(DTensorTestBase):
+    # Common logic for testing prepare output funcs
+    def _test_prepare_output(self, func, spec, dim=None):
+        device_mesh = DeviceMesh(self.device_type, [0, 1, 2, 3])
+        tensor = torch.rand(8, 16, device=self.device_type)
+        dtensor = distribute_tensor(tensor, device_mesh, spec)
+        if dim is not None:
+            output = func(dtensor, device_mesh, dim)
+        else:
+            output = func(dtensor, device_mesh)
+        return output, dtensor, device_mesh
+
+    @with_comms
+    def test_make_output_shard_1d(self):
+        # test when output is sharded.
+        output, dtensor, device_mesh = self._test_prepare_output(
+            make_output_shard_1d, [Shard(0)], 1
+        )
+        self.assertEqual(output, dtensor.redistribute(device_mesh, [Shard(1)]))
+        #  test when output is replicated.
+        output, dtensor, device_mesh = self._test_prepare_output(
+            make_output_shard_1d, [Replicate()], 0
+        )
+        self.assertEqual(output, dtensor.redistribute(device_mesh, [Shard(0)]))
+
+    @with_comms
+    def test_make_output_replicate_1d(self):
+        output, dtensor, device_mesh = self._test_prepare_output(
+            make_output_replicate_1d, [Shard(0)]
+        )
+        self.assertEqual(
+            output, dtensor.redistribute(device_mesh, [Replicate()])
+        )
+
+    @with_comms
+    def test_make_output_tensor(self):
+        # test when output is sharded.
+        output, dtensor, device_mesh = self._test_prepare_output(
+            make_output_tensor, [Shard(0)]
+        )
+        self.assertEqual(
+            output, dtensor.redistribute(device_mesh, [Replicate()]).to_local()
+        )
+        #  test when output is replicated.
+        output, dtensor, device_mesh = self._test_prepare_output(
+            make_output_tensor, [Replicate()]
+        )
+        self.assertEqual(
+            output, dtensor.redistribute(device_mesh, [Replicate()]).to_local()
+        )
+
+    # Common logic for testing prepare output funcs errors.
+    def _test_prepare_output_error(self, func):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        device_mesh = DeviceMesh(self.device_type, [0, 1, 2, 3])
+        dtensor = distribute_tensor(tensor, device_mesh, [Shard(0)])
+        output = [dtensor]
+        with self.assertRaisesRegex(
+            AssertionError,
+            f"output of Tensor Parallel is actually {type(output)} not DTensor.",
+        ):
+            func(output, device_mesh)
+        device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
+        with self.assertRaisesRegex(
+            AssertionError, f"{func.__name__}: device mesh is not 1D"
+        ):
+            func(dtensor, device_mesh)
+
+    @with_comms
+    def test_prepare_output_error(self):
+        self._test_prepare_output_error(make_output_shard_1d)
+        self._test_prepare_output_error(make_output_replicate_1d)
+        self._test_prepare_output_error(make_output_tensor)

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -74,7 +74,8 @@ class TensorParallelStyleTest(DTensorTestBase):
             func(output, device_mesh)
         device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
         with self.assertRaisesRegex(
-            AssertionError, f"{func.__name__}: device mesh is not 1D"
+            AssertionError,
+            f"device_mesh has dims 2 but expcted to be 1 for output.",
         ):
             func(dtensor, device_mesh)
 

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -69,7 +69,7 @@ class TensorParallelStyleTest(DTensorTestBase):
         output = [dtensor]
         with self.assertRaisesRegex(
             AssertionError,
-            f"output of Tensor Parallel is actually {type(output)} not DTensor.",
+            f"Expect output of Tensor Parallel to be a DTensor, but found {type(output)}.",
         ):
             func(output, device_mesh)
         device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -75,7 +75,7 @@ class TensorParallelStyleTest(DTensorTestBase):
         device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
         with self.assertRaisesRegex(
             AssertionError,
-            f"device_mesh has dims 2 but expcted to be 1 for output.",
+            "device_mesh has dims 2 but expcted to be 1 for output.",
         ):
             func(dtensor, device_mesh)
 


### PR DESCRIPTION
This is part of efforts trying to standardize and make Tensor Parallel(TP) API Beta Release. 

Since we will use DTensor for all TP internal interactions, we need to convert the output to the state(DTensor / Tensor) which user wants.