### PR TITLE
GSPMD PiPPy

### DIFF
--- a/.github/workflows/pippy_gpu_tests.sh
+++ b/.github/workflows/pippy_gpu_tests.sh
@@ -36,6 +36,7 @@ set -ex
 python3 test/local_test_forward.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 test/local_test_forward_backward.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 examples/hf/gpt2/pippy_gpt2.py --replicate ${REPLICATE} -s ${SCHEDULE}
+python3 examples/gspmd/pippy_gspmd.py --replicate ${REPLICATE} -s ${SCHEDULE}
 
 # Run flaky integration tests
 python3 test/local_test_ddp.py --replicate ${REPLICATE} -s ${SCHEDULE} || true

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -243,7 +243,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
 
-  dynamo_test:
+  programming_model_tests:
     runs-on: linux.4xlarge
     strategy:
       matrix:
@@ -263,3 +263,5 @@ jobs:
         run: "python setup.py install"
       - name: Test PiPPy + Dynamo example
         run: python examples/TorchDynamo/pippy_dynamo.py
+      - name: Run PiPPy in GSPMD style
+        run: python examples/gspmd/pippy_gspmd.py

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -34,7 +34,7 @@ pippy.fx.Tracer.proxy_buffer_attributes = True
 
 
 d_hid = 512
-bs = 503
+bs = 500
 
 class ExampleCode(torch.nn.Module):
     def __init__(self):
@@ -92,10 +92,11 @@ def run_gspmd(_, args):
     args_chunk_spec = (TensorChunkSpec(0),)
     kwargs_chunk_spec: Dict = {}
     output_chunk_spec = {"out": TensorChunkSpec(0)}
+    chunks = 5
 
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
-        1,
+        chunks,
         args_chunk_spec,
         kwargs_chunk_spec,
         output_chunk_spec,

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -68,7 +68,7 @@ def retrieve_stage_mod(stage_name):
     return stage_mod
 
 
-def run_master(_, args):
+def run_gspmd(_, args):
     MULTI_USE_PARAM_CONFIG = (
         MultiUseParameterConfig.REPLICATE
         if args.replicate
@@ -154,7 +154,8 @@ def main(args=None):
     if args.schedule == "Interleaved1F1B":
         args.world_size = 2
 
-    run_pippy(run_master, args)
+    args.gspmd = 1
+    run_pippy(run_gspmd, args)
 
 
 if __name__ == "__main__":

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import argparse
+import logging
+import os
+import unittest
+from typing import Dict
+
+import torch
+import torch.autograd.profiler_legacy
+
+import pippy.fx
+from pippy import run_pippy
+from pippy.IR import MultiUseParameterConfig, Pipe, pipe_split
+from pippy.PipelineDriver import (
+    PipelineDriverBase,
+    PipelineDriverFillDrain,
+    PipelineDriver1F1B,
+    PipelineDriverInterleaved1F1B,
+)
+from pippy.microbatch import TensorChunkSpec
+
+schedules = {
+    "FillDrain": PipelineDriverFillDrain,
+    "1F1B": PipelineDriver1F1B,
+    "Interleaved1F1B": PipelineDriverInterleaved1F1B,
+}
+
+VERBOSE = bool(int(os.environ.get("VERBOSE", False)))
+
+if VERBOSE:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+pippy.fx.Tracer.proxy_buffer_attributes = True
+
+
+d_hid = 512
+bs = 503
+
+class ExampleCode(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+        self.register_buffer("buffer", torch.randn(bs + 100, d_hid))
+
+    def forward(self, x):
+        x = torch.mm(x, self.mm_param)
+        skip_connection = x
+        x = torch.relu(x)
+        pipe_split()
+        x = torch.mm(x, self.mm_param) + self.buffer[: x.shape[0]]
+        x = self.lin(x)
+        pipe_split()
+        x = torch.relu(x)
+        x = x + skip_connection
+        x = torch.mm(x, self.mm_param2)
+        pipe_split()
+        x = self.lin(x)
+        x = torch.relu(x)
+        return {"out": x}
+
+
+def retrieve_stage_mod(stage_name):
+    stage_mod = SPLIT_GM.get_submodule(stage_name)
+    print(f"Materializing {stage_name} on {DEVICE}:\n{stage_mod}\n")
+    stage_mod.to(DEVICE)
+    return stage_mod
+
+
+def run_master(_, args):
+    MULTI_USE_PARAM_CONFIG = (
+        MultiUseParameterConfig.REPLICATE
+        if args.replicate
+        else MultiUseParameterConfig.TRANSMIT
+    )
+
+    # Make sure all ranks have the same seed
+    torch.manual_seed(5)
+    ec = ExampleCode()
+
+    ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
+    global SPLIT_GM
+    SPLIT_GM = ec_pipe.split_gm
+
+    global DEVICE
+    DEVICE = args.device
+
+    if args.rank > 0:
+        return  # Workers stop here
+
+    args_chunk_spec = (TensorChunkSpec(0),)
+    kwargs_chunk_spec: Dict = {}
+    output_chunk_spec = {"out": TensorChunkSpec(0)}
+
+    pipe_driver: PipelineDriverBase = schedules[args.schedule](
+        ec_pipe,
+        1,
+        args_chunk_spec,
+        kwargs_chunk_spec,
+        output_chunk_spec,
+        args.world_size,
+        _debug_mask_minibatches=True,
+        _record_mem_dumps=bool(args.record_mem_dumps),
+        checkpoint=bool(args.checkpoint),
+        stage_mod_cb=retrieve_stage_mod,
+    )
+
+    # # Warm up and correctness runs
+    ec_input = torch.randn(bs, d_hid, device=args.device)
+    out = pipe_driver(ec_input)
+
+    ec.to(args.device)
+    ref_out = ec(ec_input)
+
+    torch.testing.assert_close(out["out"], ref_out["out"])
+    print(
+        f'equivalence test passed {torch.sum(out["out"])} ref {torch.sum(ref_out["out"])}'
+    )
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size", type=int, default=int(os.getenv("WORLD_SIZE", 4))
+    )
+    parser.add_argument("--rank", type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument(
+        "--master_addr", type=str, default=os.getenv("MASTER_ADDR", "localhost")
+    )
+    parser.add_argument(
+        "--master_port", type=str, default=os.getenv("MASTER_PORT", "29500")
+    )
+    parser.add_argument(
+        "-s",
+        "--schedule",
+        type=str,
+        default=list(schedules.keys())[0],
+        choices=schedules.keys(),
+    )
+    parser.add_argument(
+        "--replicate", type=int, default=int(os.getenv("REPLICATE", "0"))
+    )
+    parser.add_argument(
+        "--cuda", type=int, default=int(torch.cuda.is_available())
+    )
+    parser.add_argument(
+        "--record_mem_dumps", type=int, default=0, choices=[0, 1]
+    )
+    parser.add_argument("--checkpoint", type=int, default=0, choices=[0, 1])
+    args = parser.parse_args(args)
+
+    # Interleaved 1F1B uses less ranks than number of stages
+    if args.schedule == "Interleaved1F1B":
+        args.world_size = 2
+
+    run_pippy(run_master, args)
+
+
+if __name__ == "__main__":
+    main()
+
+
+class LocalTestGspmdTest(unittest.TestCase):
+    def test_forward(self):
+        import random
+
+        port = random.randint(29500, 30000)
+        args = [
+            "--cuda",
+            os.getenv("USE_CUDA", "0"),
+            "--master_port",
+            str(port),
+        ]
+        main(args)

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1464,7 +1464,7 @@ class PipelineDriverBase(torch.nn.Module):
                 logging.debug(
                     f"[root] Moving stage_id = {stage_id} mod to {self.device}"
                 )
-                descr.mod.to(self.device)
+                descr.mod.to(self.device)   # type: ignore[union-attr]
             logging.debug(f"[root] Sending stage_id = {stage_id} mod to worker")
             self.remote_stage_executor_rrefs[descr.name] = (
                 stage_id,

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1385,7 +1385,7 @@ class PipelineDriverBase(torch.nn.Module):
 
         class ExecutorDescriptor:
             name: str
-            mod: torch.nn.Module
+            mod: Optional[torch.nn.Module]
             has_backward: bool = False
 
         split_gm = self.pipe.split_gm
@@ -1488,7 +1488,7 @@ class PipelineDriverBase(torch.nn.Module):
                 logging.debug(
                     f"[root] Deleting stage_id = {stage_id} mod on master"
                 )
-                descr.mod = None  # type: ignore[assignment]
+                descr.mod = None
             self.stage_to_executor[stage_id] = self.remote_stage_executor_rrefs[
                 descr.name
             ][1]

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1464,7 +1464,8 @@ class PipelineDriverBase(torch.nn.Module):
                 logging.debug(
                     f"[root] Moving stage_id = {stage_id} mod to {self.device}"
                 )
-                descr.mod.to(self.device)   # type: ignore[union-attr]
+                if descr.mod:
+                    descr.mod.to(self.device)  # type: ignore[union-attr]
             logging.debug(f"[root] Sending stage_id = {stage_id} mod to worker")
             self.remote_stage_executor_rrefs[descr.name] = (
                 stage_id,

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -187,4 +187,7 @@ def run_worker(rank, run_master, args, *extra_args):
         args.driver_index = rank
         args.local_driver_index = os.getenv("LOCAL_RANK", rank)
         run_master(pp_ranks_per_dp_group[rank], args, *extra_args)
+    else:
+        run_master([], args, *extra_args)
+
     rpc.shutdown()

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -57,7 +57,7 @@ def tp_transports():
     return ["shm", "uv"] if has_efa() else None
 
 
-def run_pippy(run_master, args, *extra_args):
+def run_pippy(run_func, args, *extra_args):
     if not hasattr(args, "world_size"):
         assert hasattr(args, "pp_group_size")
         args.dp_group_size = (
@@ -93,17 +93,17 @@ def run_pippy(run_master, args, *extra_args):
     if args.rank == -1:
         mp.spawn(
             run_worker,
-            args=(run_master, args, *extra_args),
+            args=(run_func, args, *extra_args),
             nprocs=actual_world_size,
             join=True,
         )
     elif args.rank < actual_world_size:
-        run_worker(args.rank, run_master, args, *extra_args)
+        run_worker(args.rank, run_func, args, *extra_args)
     else:
         print("I'm unused, exiting")
 
 
-def run_worker(rank, run_master, args, *extra_args):
+def run_worker(rank, run_func, args, *extra_args):
     args.rank = rank
 
     os.environ["MASTER_ADDR"] = args.master_addr
@@ -182,12 +182,15 @@ def run_worker(rank, run_master, args, *extra_args):
     exclude_master = (  # type: ignore[name-defined]
         args.exclude_master if hasattr(args, "exclude_master") else 0
     )
+    gspmd = (  # type: ignore[name-defined]
+        args.gspmd if hasattr(args, "gspmd") else 0
+    )
 
     if rank >= 0 and rank // args.dp_group_size == 0:
         args.driver_index = rank
         args.local_driver_index = os.getenv("LOCAL_RANK", rank)
-        run_master(pp_ranks_per_dp_group[rank], args, *extra_args)
-    else:
-        run_master([], args, *extra_args)
+        run_func(pp_ranks_per_dp_group[rank], args, *extra_args)
+    elif gspmd == 1:
+        run_func([], args, *extra_args)
 
     rpc.shutdown()


### PR DESCRIPTION
### Purpose
This is a first step towards stage-local materialization (for super-large models).

### Implementation
In this GSPMD programming style, each rank would:

1. perform tracing
2. provide a stage module retrieval callback, which would:
    - retrieve the rank's own stage from the traced graph module
    - materialize that stage

Note that all ranks must have the same seed.

### Tests
```
PiPPy/examples/gspmd$ python pippy_gspmd.py
```
Output: [gist](https://gist.github.com/kwen2501/2281b67e3a8e143360e59dc6ec508c02) 

Cc: @anj-s @HamidShojanazeri 