### PR TITLE
[Tensor Parallel] Add more ParallelStyle subclass to unblock low-level module parallelize APIs

### DIFF
--- a/spmd/tensor/parallel/__init__.py
+++ b/spmd/tensor/parallel/__init__.py
@@ -11,6 +11,8 @@ from spmd.tensor.parallel.api import (
 
 from spmd.tensor.parallel.style import (
     ParallelStyle,
+    RowwiseParallel,
+    ColwiseParallel,
     make_input_shard_1d,
     make_input_replicate_1d,
     make_output_shard_1d,

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -28,6 +28,26 @@ class ParallelStyle(ABC):
     _prepare_output: Optional[_Prepare_Output_Func_Type]
 
 
+class RowwiseParallel(ParallelStyle):
+    """
+    Partitioning the row of a module.
+    We assume the input to be a sharded :class:``DTensor`` and output to be a replicated :class:``DTensor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(make_input_shard_1d, make_output_replicate_1d)
+
+
+class ColwiseParallel(ParallelStyle):
+    """
+    Partitioning the column of a tensor or module.
+    We assume the input to be a replicated :class:``DTensor`` and output to be a sharded :class:``DTensor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(make_input_replicate_1d, None)
+
+
 @_prepare_input_validate  # type: ignore[arg-type] # pyre-ignore[56]
 def make_input_shard_1d(
     input: Union[torch.Tensor, DTensor],
@@ -35,7 +55,7 @@ def make_input_shard_1d(
     dim: int = 0,
 ) -> DTensor:
     """
-    Shard input tensor on `dim` over an 1-D device mesh. This function will be used in ParallelStyle.
+    Shard input tensor on ``dim`` over an 1-D device mesh. This function will be used in ParallelStyle.
 
     Args:
         input (Union[Tensor, DTensor]):

--- a/test/spmd/tensor/parallel/test_tp_style.py
+++ b/test/spmd/tensor/parallel/test_tp_style.py
@@ -15,6 +15,8 @@ from spmd.tensor import (
     Replicate,
 )
 from spmd.tensor.parallel.style import (
+    RowwiseParallel,
+    ColwiseParallel,
     make_input_shard_1d,
     make_input_replicate_1d,
     make_output_shard_1d,
@@ -24,55 +26,40 @@ from spmd.tensor.parallel.style import (
 
 
 class TensorParallelStyleTest(DTensorTestBase):
-    @with_comms
-    def test_make_input_replicate_1d(self):
-        tensor = torch.rand(8, 16, device=self.device_type)
+    def _1d_input_func_check(
+        self, input_local_tensor, expected_local_tensor, func
+    ) -> None:
         with self.assertRaisesRegex(
             RuntimeError, "device_mesh is not passed nor can be inferred"
         ):
-            dtensor = make_input_replicate_1d(tensor)
+            dtensor = func(input_local_tensor)
         device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
         with self.assertRaisesRegex(
             RuntimeError,
             "device_mesh has dims [0-9]+ but expcted to be 1 for input.",
         ):
-            dtensor = make_input_replicate_1d(tensor, device_mesh)
+            dtensor = func(input_local_tensor, device_mesh)
 
         device_mesh = DeviceMesh(self.device_type, list(range(NUM_DEVICES)))
         # test 1: replicate local tensor
-        dtensor = make_input_replicate_1d(tensor, device_mesh)
-        self.assertEqual(tensor, dtensor.to_local())
+        dtensor = func(input_local_tensor, device_mesh)
+        self.assertEqual(expected_local_tensor, dtensor.to_local())
         # test 2: replicate DTensor
-        dtensor = make_input_replicate_1d(dtensor)
-        self.assertEqual(tensor, dtensor.to_local())
+        dtensor = func(dtensor)
+        self.assertEqual(expected_local_tensor, dtensor.to_local())
         # test 3: replicate DTensor with DeviceMesh passed
-        dtensor = make_input_replicate_1d(dtensor, device_mesh)
-        self.assertEqual(tensor, dtensor.to_local())
+        dtensor = func(dtensor, device_mesh)
+        self.assertEqual(expected_local_tensor, dtensor.to_local())
+
+    @with_comms
+    def test_make_input_replicate_1d(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        self._1d_input_func_check(tensor, tensor, make_input_replicate_1d)
 
     @with_comms
     def test_make_input_shard_1d(self):
         tensor = torch.rand(8, 16, device=self.device_type)
-        with self.assertRaisesRegex(
-            RuntimeError, "device_mesh is not passed nor can be inferred"
-        ):
-            dtensor = make_input_shard_1d(tensor)
-        device_mesh = DeviceMesh(self.device_type, [[0, 1], [2, 3]])
-        with self.assertRaisesRegex(
-            RuntimeError,
-            "device_mesh has dims [0-9]+ but expcted to be 1 for input.",
-        ):
-            dtensor = make_input_shard_1d(tensor, device_mesh)
-
-        device_mesh = DeviceMesh(self.device_type, list(range(NUM_DEVICES)))
-        # test 1: shard local Tensor on default dim
-        dtensor = make_input_shard_1d(tensor, device_mesh)
-        self.assertEqual(tensor, dtensor.to_local())
-        # test 2: reshard DTensor
-        dtensor = make_input_shard_1d(dtensor)
-        self.assertEqual(tensor, dtensor.to_local())
-        # test 3: reshard DTensor with DeviceMesh passed
-        dtensor = make_input_shard_1d(dtensor, device_mesh)
-        self.assertEqual(tensor, dtensor.to_local())
+        self._1d_input_func_check(tensor, tensor, make_input_shard_1d)
 
     # Common logic for testing prepare output funcs
     def _test_prepare_output(
@@ -169,6 +156,34 @@ class TensorParallelStyleTest(DTensorTestBase):
         self._test_prepare_output_error(make_output_shard_1d)
         self._test_prepare_output_error(make_output_replicate_1d)
         self._test_prepare_output_error(make_output_tensor)
+
+    @with_comms
+    def test_rowwise_parallel_style(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        rs = RowwiseParallel()
+        self._1d_input_func_check(tensor, tensor, rs._prepare_input)
+        # TODO: change output test
+        output, dtensor, device_mesh = self._test_prepare_output(
+            rs._prepare_input, [Shard(0)]
+        )
+        self.assertEqual(
+            output, dtensor.redistribute(device_mesh, [Replicate()])
+        )
+        # test when input device_mesh is None.
+        output, dtensor, device_mesh = self._test_prepare_output(
+            rs._prepare_input, [Shard(0)], None, True
+        )
+        self.assertEqual(
+            output, dtensor.redistribute(device_mesh, [Replicate()])
+        )
+        self._test_prepare_output_error(rs._prepare_output)
+
+    @with_comms
+    def test_colwise_parallel_style(self):
+        tensor = torch.rand(8, 16, device=self.device_type)
+        cs = ColwiseParallel()
+        self._1d_input_func_check(tensor, tensor, cs._prepare_input)
+        self.assertEqual(None, cs._prepare_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Goal:

- To unblock adding low-level module parallelize APIs `_parallelize_linear` and `_parallelize_mlp`.

What's in this PR:

- added row-wise and column-wise module parallelization styles.
- added unit tests to check initialization of new styles and the correctness of their input/output preparation functions.
- increased code reuse of unit tests.

Next Step:

- `_parallelize_linear`