### PR TITLE
Introduce defer_stage_init API

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -7,7 +7,6 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.fx as torch_fx
-from torch.nn.modules.module import Module
 import pippy.fx
 from packaging import version
 from pippy.fx.passes.split_module import split_module
@@ -993,15 +992,12 @@ class Pipe(torch.nn.Module):
     def __repr__(self):
         return self.split_gm.__repr__()
 
-    def get_submodule(self, target: str) -> "Module":
-        return self.split_gm.get_submodule(target)
-
     def defer_stage_init(self, device):
         global materialize_stage
 
-        def materialize_stage(target: str) -> "Module":
+        def materialize_stage(target: str) -> torch.nn.Module:
             logging.info(f"Materializing {target} on {device}")
-            return self.get_submodule(target).to(device)
+            return self.split_gm.get_submodule(target).to(device)
 
     @staticmethod
     def is_stage_init_deferred():

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -993,15 +993,15 @@ class Pipe(torch.nn.Module):
         return self.split_gm.__repr__()
 
     def defer_stage_init(self, device):
-        global materialize_stage
-
         def materialize_stage(target: str) -> torch.nn.Module:
             logging.info(f"Materializing {target} on {device}")
             return self.split_gm.get_submodule(target).to(device)
 
+        setattr(Pipe, "materialize_stage", materialize_stage)
+
     @staticmethod
     def is_stage_init_deferred():
-        return "materialize_stage" in globals()
+        return hasattr(Pipe, "materialize_stage")
 
 
 class PipeSplitWrapper(torch.nn.Module):

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -1004,7 +1004,7 @@ class Pipe(torch.nn.Module):
             return self.get_submodule(target).to(device)
 
     @staticmethod
-    def is_stage_init_enabled():
+    def is_stage_init_deferred():
         return "materialize_stage" in globals()
 
 

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -1394,7 +1394,7 @@ class PipelineDriverBase(torch.nn.Module):
             if node.op == "call_module":
                 descr = ExecutorDescriptor()
                 descr.name = node.target
-                if Pipe.is_stage_init_enabled():
+                if Pipe.is_stage_init_deferred():
                     descr.mod = None
                 else:
                     descr.mod = split_gm.get_submodule(node.target)
@@ -1475,7 +1475,7 @@ class PipelineDriverBase(torch.nn.Module):
                     mod_name=descr.name,
                 ),
             )
-            if self.device is not None or Pipe.is_stage_init_enabled():
+            if self.device is not None or Pipe.is_stage_init_deferred():
                 logging.debug(
                     f"[root] Waiting stage_id = {stage_id} mod to be confirmed by worker"
                 )

--- a/pippy/PipelineDriver.py
+++ b/pippy/PipelineDriver.py
@@ -261,7 +261,7 @@ class RankWorker(EventRecorder):
 
         self.stage_executors[stage_id] = PipeStageExecutor(
             stage_id=stage_id,
-            mod=mod or pippy.IR.materialize_stage(mod_name),
+            mod=mod or Pipe.materialize_stage(mod_name),
             rank_worker=self,
             _record_mem_dumps=self._record_mem_dumps,
         )


### PR DESCRIPTION
- Introduce `Pipe.defer_stage_init` API
- Move stage retrieval and materialization inside PiPPy so that users do not need to define this function in their code