### PR TITLE
[PT-D][Tensor Parallelism] Implement parallelize_module API and refactor _parallelize_multihead_attn

### DIFF
--- a/spmd/tensor/parallel/__init__.py
+++ b/spmd/tensor/parallel/__init__.py
@@ -4,9 +4,7 @@ from spmd.tensor.parallel.multihead_attention_tp import (
 )
 
 from spmd.tensor.parallel.api import (
-    tp_shard_self_attn,
-    replicate_input,
-    replicate_output,
+    parallelize_module,
 )
 
 from spmd.tensor.parallel.style import (
@@ -20,3 +18,17 @@ from spmd.tensor.parallel.style import (
     make_output_replicate_1d,
     make_output_tensor,
 )
+
+__all__ = [
+    "TensorParallelMultiheadAttention",
+    "parallelize_module",
+    "ParallelStyle",
+    "PairwiseParallel",
+    "RowwiseParallel",
+    "ColwiseParallel",
+    "make_input_shard_1d",
+    "make_input_replicate_1d",
+    "make_output_shard_1d",
+    "make_output_replicate_1d",
+    "make_output_tensor",
+]

--- a/spmd/tensor/parallel/__init__.py
+++ b/spmd/tensor/parallel/__init__.py
@@ -3,32 +3,32 @@ from spmd.tensor.parallel.multihead_attention_tp import (
     TensorParallelMultiheadAttention,
 )
 
+from spmd.tensor.parallel.style import (
+    ColwiseParallel,
+    ParallelStyle,
+    PairwiseParallel,
+    RowwiseParallel,
+    make_input_replicate_1d,
+    make_input_shard_1d,
+    make_output_replicate_1d,
+    make_output_shard_1d,
+    make_output_tensor,
+)
+
 from spmd.tensor.parallel.api import (
     parallelize_module,
 )
 
-from spmd.tensor.parallel.style import (
-    ParallelStyle,
-    PairwiseParallel,
-    RowwiseParallel,
-    ColwiseParallel,
-    make_input_shard_1d,
-    make_input_replicate_1d,
-    make_output_shard_1d,
-    make_output_replicate_1d,
-    make_output_tensor,
-)
-
 __all__ = [
+    "ColwiseParallel",
     "TensorParallelMultiheadAttention",
-    "parallelize_module",
     "ParallelStyle",
     "PairwiseParallel",
     "RowwiseParallel",
-    "ColwiseParallel",
-    "make_input_shard_1d",
     "make_input_replicate_1d",
-    "make_output_shard_1d",
+    "make_input_shard_1d",
     "make_output_replicate_1d",
     "make_output_tensor",
+    "make_output_shard_1d",
+    "parallelize_module",
 ]

--- a/spmd/tensor/parallel/api.py
+++ b/spmd/tensor/parallel/api.py
@@ -1,106 +1,128 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import torch
 import torch.nn as nn
-from typing import Sequence, Tuple
+from typing import Union, Dict
 from spmd.tensor import (
     distribute_module,
     distribute_tensor,
-    DTensor,
     Shard,
     Replicate,
     DeviceMesh,
-    Placement,
 )
 from spmd.tensor.parallel import TensorParallelMultiheadAttention
-from spmd.tensor.parallel.style import ParallelStyle, PairwiseParallel
+from spmd.tensor.parallel.style import PairwiseParallel, ParallelStyle
 from spmd.tensor.parallel.utils import _create_1d_device_mesh
 
 
-def replicate_input(
-    inputs: Sequence[torch.Tensor], device_mesh: DeviceMesh
-) -> Tuple[DTensor, ...]:
-    replicate = [Replicate()] * device_mesh.ndim
-    return tuple(
-        DTensor.from_local(tensor, device_mesh, replicate) for tensor in inputs
-    )
+__all__ = [
+    "parallelize_module",
+]
 
 
-def replicate_output(output: DTensor, device_mesh: DeviceMesh) -> torch.Tensor:
-    if isinstance(output, DTensor):
-        replicate = [Replicate()] * output.device_mesh.ndim
-        # TODO: can the output be left incontiguous?
-        return (
-            output.redistribute(output.device_mesh, replicate)
-            .to_local()
-            .contiguous()
+def parallelize_module(
+    module: nn.Module,
+    device_mesh: DeviceMesh,
+    parallelize_plan: Union[ParallelStyle, Dict[str, ParallelStyle]],
+    tp_mesh_dim: int = 0,
+) -> nn.Module:
+    """
+    The major API for tensor parallelism in PyTorch. We parallelize module
+    or sub_modules based on a parallelize_plan which contains the parallel_style
+    which indicates how user want the module or sub_module to be parallelized.
+    User can also specify different parallel_style per FQN. The API supports 2D
+    parallelism natively by accepting an n-dimension device_mesh and users just
+    need to specify the dimension where we perform tensor parallelism on.
+
+    Args:
+        module (nn.Module):
+            :class:``nn.Module`` object to be parallelized.
+        device_mesh (DeviceMesh):
+            :class:``DeviceMesh`` object which describes the mesh topology
+            of devices for the DTensor.
+        parallelize_plan (Union[ParallelStyle, Dict[str, ParallelStyle]]):
+            The plan used to parallelize the module. It can be either a
+            :class:``ParallelStyle`` object which contains how
+            we prepare input/output for Tensor Parallelism or it can be a
+            dict of FQN and its corresponding :class:``ParallelStyle`` object.
+        tp_mesh_dim (int):
+            the dimension of ``device_mesh`` where we perform
+            Tensor Parallelism on.
+
+    Return:
+        A :class:``nn.Module`` object parallelized.
+
+    Example::
+        >>> # xdoctest: +SKIP("distributed")
+        >>> from from spmd.tensor.parallel import parallelize_module, PairwiseParallel
+        >>>
+        >>> # Define the module.
+        >>> m = Model(...)
+        >>> m = parallelize_module(m, PairwiseParallel())
+        >>>
+
+    .. warning::
+        ``PairwiseParallel`` comes with constraints for now. If you need finer
+        granularity 
+    """
+
+    if device_mesh.ndim > 1:
+        device_mesh = _create_1d_device_mesh(device_mesh, tp_mesh_dim)
+
+    if isinstance(parallelize_plan, ParallelStyle):
+        if _is_mha_for_pairwise_parallel(module):
+            return _parallelize_multihead_attn(module, device_mesh)
+        elif _is_mlp_for_pairwise_parallel(module):
+            return _parallelize_mlp(module, device_mesh)
+        else:
+            for n, m in module.named_children():
+                module.register_module(
+                    n, parallelize_module(m, device_mesh, parallelize_plan)
+                )
+            return module
+    elif isinstance(parallelize_plan, dict):
+        for module_path, parallelize_style in parallelize_plan.items():
+            sub_module = module.get_submodule(module_path)
+            module.register_module(
+                parallelize_module(
+                    module_path, sub_module, device_mesh, parallelize_style
+                )
+            )
+            return module
+    # TODO: Add parallelize linear logic when https://github.com/pytorch/tau/pull/624/ merged.
+    else:
+        raise RuntimeError(
+            f"Expect Union[ParallelStyle, Dict[str, ParallelStyle]] for parallelize_plan, {type(parallelize_plan)} found!"
         )
 
 
-def tp_shard_self_attn(
-    name: str, module: nn.Module, device_mesh: DeviceMesh
-) -> None:
-    col_wise_sharding: Sequence[Placement] = [Shard(0)]
-    row_wise_sharding: Sequence[Placement] = [Shard(1)]
-    replicate: Sequence[Placement] = [Replicate()] * device_mesh.ndim
-
-    def _shard_self_attn_params(name: str, module: nn.Module) -> None:
-        if isinstance(module, nn.Linear):
-            if name == "qkv":
-                sharded_weight = nn.Parameter(
-                    distribute_tensor(
-                        module.weight, device_mesh, col_wise_sharding
-                    )
-                )
-                module.register_parameter("weight", sharded_weight)
-                if module.bias is not None:
-                    sharded_bias = nn.Parameter(
-                        distribute_tensor(
-                            module.bias, device_mesh, col_wise_sharding
-                        )
-                    )
-                    module.register_parameter("bias", sharded_bias)
-            elif name == "proj":
-                sharded_weight = nn.Parameter(
-                    distribute_tensor(
-                        module.weight, device_mesh, row_wise_sharding
-                    )
-                )
-                module.register_parameter("weight", sharded_weight)
-                if module.bias is not None:
-                    replicated_bias = nn.Parameter(
-                        distribute_tensor(module.bias, device_mesh, replicate)
-                    )
-                    module.register_parameter("bias", replicated_bias)
-
-    if isinstance(module, TensorParallelMultiheadAttention):  # shard TPMA
-        for n, m in module.named_children():
-            _shard_self_attn_params(n, m)
-    else:
-        for n, m in module.named_children():  # replace with TPMA
-            if isinstance(m, nn.MultiheadAttention):
-                tp_multi_head_attention = TensorParallelMultiheadAttention(
-                    m.embed_dim,
-                    m.num_heads,
-                    device=torch.device(device_mesh.device_type),
-                    tp_size=device_mesh.size(0),  # group size on dim 0
-                    add_bias_kv=m.bias_k is not None,
-                )
-                tp_multi_head_attention.copy(m)
-                module.register_module(n, tp_multi_head_attention)
-
-
-def _has_even_num_linears(module: nn.Module) -> bool:
+def _is_mha_for_pairwise_parallel(module: nn.Module) -> bool:
     """
-    We traverse through all the children of the given module and count the
-    number of Linear module. If the number is even, we return True.
+    Check whether the mha module is the one can be handled for Pairwise parallel.
+
+    Args:
+        module (nn.Module):
+            :class:``nn.Module`` object to be checked.
+
+    Return:
+        A boolean object which specifies whether the module is MHA supported by Pairwise parallel or not.
+    """
+    if isinstance(module, TensorParallelMultiheadAttention) or isinstance(
+        module, nn.MultiheadAttention
+    ):
+        return True
+
+
+def _is_mlp_for_pairwise_parallel(module: nn.Module) -> bool:
+    """
+    Traverse through all the children of the given module and count the
+    number of Linear module. If the number is more than one, we return True.
 
     Args:
         module (nn.Module):
             :class:``nn.Module`` object to be traversed and counted.
 
     Return:
-        A boolean object which specifies whether the module contains
-        event-number of Linears in its children.
+        A boolean object which specifies whether the module is MLP or not.
 
     .. warning::
         The traversal is not recursive for now.
@@ -108,15 +130,66 @@ def _has_even_num_linears(module: nn.Module) -> bool:
     linear_submodules = list(
         filter(lambda x: isinstance(x, nn.Linear), module.children())
     )
-    return len(linear_submodules) > 0 and len(linear_submodules) % 2 == 0
+    return len(linear_submodules) > 0
 
 
-def _parallelize_mlp(
+def _rowwise_parallelize_linear_fn(
+    name: str,
+    module: nn.Module,
+    device_mesh: DeviceMesh,
+) -> None:
+    """
+    This function parallelizes the input :class:``nn.Linear`` module in :class:``RowwiseParallel`` style.
+
+    Args:
+        name (str): name of the input module.
+        module (nn.Module): the :class:``nn.Linear`` object to be parallelized.
+        device_mesh (DeviceMesh): :class:``DeviceMesh`` object which describes the mesh topology
+            of devices for the DTensor.
+
+    Return:
+        None
+    """
+    for name, param in module.named_parameters():
+        dist_spec = (
+            [Shard(1)] if name == "weight" else [Replicate()]  # type: ignore[list-item]
+        )
+        dist_param = torch.nn.Parameter(
+            distribute_tensor(param, device_mesh, dist_spec)
+        )
+        module.register_parameter(name, dist_param)
+
+
+def _colwise_parallelize_linear_fn(
+    name: str,
+    module: nn.Module,
+    device_mesh: DeviceMesh,
+) -> None:
+    """
+    This function parallelizes the input :class:``nn.Linear`` module in :class:``ColwiseParallel`` style.
+
+    Args:
+        name (str): name of the input module.
+        module (nn.Module): the :class:``nn.Linear`` object to be parallelized.
+        device_mesh (DeviceMesh): :class:``DeviceMesh`` object which describes the mesh topology
+            of devices for the DTensor.
+
+    Return:
+        None
+    """
+    for name, param in module.named_parameters():
+        dist_param = torch.nn.Parameter(
+            distribute_tensor(param, device_mesh, [Shard(0)])
+        )
+        module.register_parameter(name, dist_param)
+
+
+def _parallelize_multihead_attn(
     module: nn.Module,
     device_mesh: DeviceMesh,
     parallel_style: ParallelStyle = PairwiseParallel(),
     tp_mesh_dim: int = 0,
-) -> None:
+) -> nn.Module:
     """
     This function assumes the input module is a sequence of nn.Linear
     and we parallelize the module based on the given parallel style.
@@ -137,37 +210,90 @@ def _parallelize_mlp(
             Tensor Parallelism on.
 
     Return:
-        None
+        A :class:``nn.Module`` object parallelized.
 
     .. warning::
         We only support ``PairwiseParallel`` right now.
     """
 
-    # Define partition functions needed.
-    def _rowwise_parallelize_fn(name, module, device_mesh):  # pyre-ignore[2, 3]
-        for name, param in module.named_parameters():
-            dist_spec = (
-                [Shard(1)] if name == "weight" else [Replicate()]  # type: ignore[list-item]
-            )
-            dist_param = torch.nn.Parameter(
-                distribute_tensor(param, device_mesh, dist_spec)
-            )
-            module.register_parameter(name, dist_param)
+    if not isinstance(parallel_style, PairwiseParallel):
+        raise NotImplementedError(
+            "Only support PairwiseParallel for Multihead Attention parallelization."
+        )
 
-    def _colwise_parallelize_fn(name, module, device_mesh):  # pyre-ignore[2, 3]
-        for name, param in module.named_parameters():
-            dist_param = torch.nn.Parameter(
-                distribute_tensor(param, device_mesh, [Shard(0)])
-            )
-            module.register_parameter(name, dist_param)
+    if device_mesh.ndim > 1:
+        device_mesh = _create_1d_device_mesh(device_mesh, tp_mesh_dim)
 
+    if isinstance(module, nn.MultiheadAttention):
+        tp_multi_head_attention = TensorParallelMultiheadAttention(
+            module.embed_dim,
+            module.num_heads,
+            device=torch.device(device_mesh.device_type),
+            tp_size=device_mesh.size(tp_mesh_dim),
+            add_bias_kv=module.bias_k is not None,
+        )
+        tp_multi_head_attention.copy(module)
+        return _parallelize_multihead_attn(tp_multi_head_attention, device_mesh)
+
+    if isinstance(module, TensorParallelMultiheadAttention):  # shard TPMA
+        for n, m in module.named_children():
+            if n == "qkv":
+                # Col-wise Parallelize the qkv layer.
+                distribute_module(
+                    m,
+                    device_mesh,
+                    _colwise_parallelize_linear_fn,
+                    input_fn=parallel_style._prepare_input,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+                )
+            elif n == "proj":
+                # Row-wise Parallelize the proj layer
+                distribute_module(
+                    m,
+                    device_mesh,
+                    _rowwise_parallelize_linear_fn,
+                    output_fn=parallel_style._prepare_output,  # type: ignore[arg-type, misc] # pyre-ignore[6]
+                )
+    return module
+
+
+def _parallelize_mlp(
+    module: nn.Module,
+    device_mesh: DeviceMesh,
+    parallel_style: ParallelStyle = PairwiseParallel(),
+    tp_mesh_dim: int = 0,
+) -> nn.Module:
+    """
+    This function assumes the input module is a sequence of nn.Linear
+    and we parallelize the module based on the given parallel style.
+    We don't change the FQN of each sub-module and replace each parameter
+    in place.
+
+    Args:
+        module (nn.Module):
+            :class:``nn.Module`` object to be parallelized.
+        device_mesh (DeviceMesh):
+            :class:``DeviceMesh`` object which describes the mesh topology
+            of devices for the DTensor.
+        parallel_style (ParallelStyle):
+            :class:``ParallelStyle`` object which contains how
+            we prepare input/output for Tensor Parallelism.
+        tp_mesh_dim (int):
+            the dimension of ``device_mesh`` where we perform
+            Tensor Parallelism on.
+
+    Return:
+        A :class:``nn.Module`` object parallelized.
+
+    .. warning::
+        We only support ``PairwiseParallel`` right now.
+    """
     if not isinstance(parallel_style, PairwiseParallel):
         raise NotImplementedError(
             "Only support PairwiseParallel for MLP parallelization."
         )
 
-    if not _has_even_num_linears(module):
-        raise RuntimeError("We only support even number of Linear for MLP.")
+    if not _is_mlp_for_pairwise_parallel(module):
+        raise RuntimeError("More than one nn.Linear needed for a MLP.")
 
     if device_mesh.ndim > 1:
         device_mesh = _create_1d_device_mesh(device_mesh, tp_mesh_dim)
@@ -175,13 +301,15 @@ def _parallelize_mlp(
     linear_submodules = list(
         filter(lambda x: isinstance(x, nn.Linear), module.children())
     )
-    for i, m in enumerate(linear_submodules):
+    mlp_last_even_layer = (len(linear_submodules) // 2) * 2
+    for i in range(mlp_last_even_layer):
+        m = linear_submodules[i]
         if i % 2 == 0:
             # Col-wise Parallelize the linear layer
             distribute_module(
                 m,
                 device_mesh,
-                _colwise_parallelize_fn,
+                _colwise_parallelize_linear_fn,
                 input_fn=parallel_style._prepare_input  # type: ignore[arg-type, misc] # pyre-ignore[6]
                 if i == 0
                 else None,
@@ -191,8 +319,9 @@ def _parallelize_mlp(
             distribute_module(
                 m,
                 device_mesh,
-                _rowwise_parallelize_fn,
+                _rowwise_parallelize_linear_fn,
                 output_fn=parallel_style._prepare_output  # type: ignore[arg-type, misc] # pyre-ignore[6]
-                if i == (len(linear_submodules) - 1)
+                if i == (mlp_last_even_layer - 1)
                 else None,
             )
+    return module

--- a/spmd/tensor/parallel/api.py
+++ b/spmd/tensor/parallel/api.py
@@ -90,7 +90,7 @@ def parallelize_module(  # type: ignore[return]
             )
             return module
     else:
-        raise RuntimeError(
+        raise RuntimeError(  # pyre-ignore[7]
             f"Expect Union[ParallelStyle, Dict[str, ParallelStyle]] for parallelize_plan, {type(parallelize_plan)} found!"
         )
 

--- a/spmd/tensor/parallel/api.py
+++ b/spmd/tensor/parallel/api.py
@@ -26,10 +26,10 @@ def parallelize_module(  # type: ignore[return]
     tp_mesh_dim: int = 0,
 ) -> nn.Module:
     """
-    The major API for tensor parallelism in PyTorch. We parallelize module
+    The API to apply Tensor Parallelism (TP) in PyTorch. We parallelize module
     or sub_modules based on a parallelize_plan which contains the parallel_style
     which indicates how user want the module or sub_module to be parallelized.
-    User can also specify different parallel_style per module fully qualifed name(FQN).
+    User can also specify different parallel_style per module fully qualifed name (FQN).
     The API supports 2D parallelism natively by accepting an n-dimension device_mesh
     and users just need to specify the dimension where we perform tensor parallelism on.
 
@@ -129,7 +129,7 @@ def _is_mlp_for_pairwise_parallel(module: nn.Module) -> bool:
     linear_submodules = list(
         filter(lambda x: isinstance(x, nn.Linear), module.children())
     )
-    return len(linear_submodules) > 0
+    return len(linear_submodules) > 1
 
 
 def _rowwise_parallelize_linear_fn(

--- a/spmd/tensor/parallel/style.py
+++ b/spmd/tensor/parallel/style.py
@@ -5,8 +5,8 @@ from abc import ABC
 from typing import Union, Optional
 from spmd.tensor import DTensor, Shard, Replicate, DeviceMesh
 from spmd.tensor.parallel.utils import (
-    _Prepare_Input_Func_Type,
-    _Prepare_Output_Func_Type,
+    _PrepareInputType,
+    _PrepareOutputType,
     _prepare_input_validate,
     _prepare_output_validate,
 )
@@ -18,8 +18,8 @@ class ParallelStyle(ABC):
     Users can extend this class to build their own parallel style with customized input/output preparations.
     """
 
-    _prepare_input: _Prepare_Input_Func_Type
-    _prepare_output: _Prepare_Output_Func_Type
+    _prepare_input: _PrepareInputType
+    _prepare_output: _PrepareOutputType
 
     @abstractmethod
     def __init__(self, _prepare_input, _prepare_output) -> None:

--- a/spmd/tensor/parallel/utils.py
+++ b/spmd/tensor/parallel/utils.py
@@ -4,18 +4,18 @@ import torch
 from spmd.tensor import DeviceMesh, DTensor
 from typing import Callable, Optional, Union
 
-_Prepare_Input_Func_Type = Callable[
+_PrepareInputType = Callable[
     [Union[torch.Tensor, DTensor], Optional[DeviceMesh], Optional[int]], DTensor
 ]
 
-_Prepare_Output_Func_Type = Callable[
+_PrepareOutputType = Callable[
     [DTensor, Optional[DeviceMesh], Optional[int]], Union[torch.Tensor, DTensor]
 ]
 
 
 def _prepare_input_validate(
-    _prepare_input_func: _Prepare_Input_Func_Type,
-) -> _Prepare_Input_Func_Type:
+    _prepare_input_func: _PrepareInputType,
+) -> _PrepareInputType:
     """
     Inject common validation logics for `_prepare_input` funcs via this
     decorator, including verifying that input needs to be either
@@ -66,8 +66,8 @@ def _prepare_input_validate(
 
 
 def _prepare_output_validate(
-    _prepare_output_func: _Prepare_Output_Func_Type,
-) -> _Prepare_Output_Func_Type:
+    _prepare_output_func: _PrepareOutputType,
+) -> _PrepareOutputType:
     """
     Inject common validation logics for _prepare_output funcs via this
     decorator, including verifying that output needs to be a DTensor

--- a/test/spmd/tensor/parallel/test_2d_parallel.py
+++ b/test/spmd/tensor/parallel/test_2d_parallel.py
@@ -17,8 +17,8 @@ from spmd.tensor import (
     Replicate,
 )
 from spmd.tensor.parallel import (
-    parallelize_module,
     PairwiseParallel,
+    parallelize_module,
 )
 
 import torch.distributed.distributed_c10d as distributed_c10d
@@ -101,10 +101,9 @@ def shard_module(m, pg):
     m.net2 = _aggregate_local_tensor(m.net2)
 
 
-def _shard_wrap_module(module, module_shard, fsdp_wrap, twod_mesh, fsdp_pg):
+def _shard_wrap_module(module, module_shard, fsdp_wrap, mesh_2d, fsdp_pg):
     if module_shard:
-        # Fetch the module sharding planner.
-        parallelize_module(module, twod_mesh, PairwiseParallel(), tp_mesh_dim=1)
+        parallelize_module(module, mesh_2d, PairwiseParallel(), tp_mesh_dim=1)
 
     if fsdp_wrap and module_shard:
         return FSDP(module, process_group=fsdp_pg)

--- a/test/spmd/tensor/parallel/test_2d_parallel.py
+++ b/test/spmd/tensor/parallel/test_2d_parallel.py
@@ -16,6 +16,10 @@ from spmd.tensor import (
     Shard,
     Replicate,
 )
+from spmd.tensor.parallel import (
+    parallelize_module,
+    PairwiseParallel,
+)
 
 import torch.distributed.distributed_c10d as distributed_c10d
 
@@ -31,17 +35,6 @@ from spmd.testing.common_dtensor import (
 # Tensor-Parallel degree
 TP_DEGREE = 2
 LR = 3e-5
-
-OPS_NOT_SHARD = [
-    "net3.weight",
-    "net3.bias",
-]
-
-SHARD_PARAMS = [
-    "net1.weight",
-    "net1.bias",
-    "net2.weight",
-]
 
 
 class SimpleModel(torch.nn.Module):
@@ -108,10 +101,10 @@ def shard_module(m, pg):
     m.net2 = _aggregate_local_tensor(m.net2)
 
 
-def _shard_wrap_module(module, module_shard, fsdp_wrap, tp_pg, fsdp_pg):
+def _shard_wrap_module(module, module_shard, fsdp_wrap, twod_mesh, fsdp_pg):
     if module_shard:
         # Fetch the module sharding planner.
-        shard_module(module, tp_pg)
+        parallelize_module(module, twod_mesh, PairwiseParallel(), tp_mesh_dim=1)
 
     if fsdp_wrap and module_shard:
         return FSDP(module, process_group=fsdp_pg)
@@ -134,11 +127,10 @@ def init_model(model_parallel_size=TP_DEGREE):
     )
 
     fsdp_pg = twod_mesh.get_dim_groups()[0]
-    tp_pg = twod_mesh.get_dim_groups()[1]
 
     # Create Input
-    model = _shard_wrap_module(model, True, True, tp_pg, fsdp_pg)
-    return model, tp_pg, fsdp_pg
+    model = _shard_wrap_module(model, True, True, twod_mesh, fsdp_pg)
+    return model, fsdp_pg
 
 
 def is_nested_tensor(val: Any) -> bool:
@@ -200,7 +192,7 @@ class Test2dParallelIntegration(DTensorTestBase):
         model = SimpleModel().cuda(self.rank)
         model = FSDP(model)
         torch.manual_seed(0)
-        model_2d, _, dp_pg = init_model()
+        model_2d, dp_pg = init_model()
 
         optim = torch.optim.Adam(model.parameters(), lr=0.0001)
         optim_2d = torch.optim.Adam(model_2d.parameters(), lr=0.0001)

--- a/test/spmd/tensor/parallel/test_parallelize_api.py
+++ b/test/spmd/tensor/parallel/test_parallelize_api.py
@@ -86,7 +86,7 @@ class TensorParallelAPITests(DTensorTestBase):
         device_mesh = DeviceMesh(
             self.device_type, torch.arange(self.world_size)
         )
-        _parallelize_mlp(model_tp, device_mesh, PairwiseParallel())
+        model_tp = _parallelize_mlp(model_tp, device_mesh, PairwiseParallel())
 
         # Ensure the parameter is properly distributed.
         self.assertEqual(
@@ -125,7 +125,7 @@ class TensorParallelAPITests(DTensorTestBase):
             _parallelize_mlp(model_tp, device_mesh, DummyParallel())
 
         with self.assertRaisesRegex(
-            RuntimeError, "We only support even number of Linear for MLP."
+            RuntimeError, "More than one nn.Linear needed for a MLP."
         ):
             _parallelize_mlp(
                 torch.nn.Linear(10, 5), device_mesh, PairwiseParallel()

--- a/test/spmd/tensor/parallel/test_tp_examples.py
+++ b/test/spmd/tensor/parallel/test_tp_examples.py
@@ -15,11 +15,10 @@ from spmd.tensor import (
     Replicate,
 )
 from spmd.tensor.parallel import (
-    parallelize_module,
     PairwiseParallel,
     TensorParallelMultiheadAttention,
+    parallelize_module,
 )
-from spmd.tensor.parallel import PairwiseParallel
 
 
 class MLPModule(torch.nn.Module):


### PR DESCRIPTION
We are building a new unified high-level API so that user can directly use it for tensor parallelism. Our tensor parallelism is built on top of DTensor (RFC: https://github.com/pytorch/pytorch/issues/88838).

We have already built some APIs for Multihead_attention parallelism and we now just refactor it to make sure it is working with our overall design for tensor parallelism.