### PR TITLE
Replace large-cpu init mode

### DIFF
--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -75,6 +75,8 @@ def run_gspmd(_, args):
     ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
     ec_pipe.defer_stage_init(args.device)
 
+    torch.distributed.barrier(args.pp_group)
+
     if args.rank > 0:
         return  # Workers stop here
 

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -61,7 +61,7 @@ class ExampleCode(torch.nn.Module):
         return {"out": x}
 
 
-def run_gspmd(_, args):
+def run_gspmd(pp_ranks, args):
     MULTI_USE_PARAM_CONFIG = (
         MultiUseParameterConfig.REPLICATE
         if args.replicate
@@ -75,8 +75,8 @@ def run_gspmd(_, args):
     ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
     ec_pipe.defer_stage_init(args.device)
 
-    # Make sure every rank has deferred its stage init because master creates the driver
-    torch.distributed.barrier(args.pp_group)
+    # Make sure every rank has deferred its stage init before master creates the driver
+    pippy.utils.pp_group_barrier()
 
     if args.rank > 0:
         return  # Workers stop here

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -75,6 +75,7 @@ def run_gspmd(_, args):
     ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
     ec_pipe.defer_stage_init(args.device)
 
+    # Make sure every rank has deferred its stage init because master creates the driver
     torch.distributed.barrier(args.pp_group)
 
     if args.rank > 0:

--- a/examples/hf/gpt2/pippy_gpt2.py
+++ b/examples/hf/gpt2/pippy_gpt2.py
@@ -120,6 +120,8 @@ def run_gspmd(_, args):
     else:
         gpt2_pipe.to(device)
 
+    torch.distributed.barrier(args.pp_group)
+
     if args.rank != 0:
         # Workers return here
         return

--- a/examples/hf/gpt2/pippy_gpt2.py
+++ b/examples/hf/gpt2/pippy_gpt2.py
@@ -117,10 +117,10 @@ def run_gspmd(_, args):
     if args.gspmd == 1:
         print(f"Deferring stage init on device {device}")
         gpt2_pipe.defer_stage_init(device)
+        # Make sure every rank has deferred its stage init because master creates the driver
+        torch.distributed.barrier(args.pp_group)
     else:
         gpt2_pipe.to(device)
-
-    torch.distributed.barrier(args.pp_group)
 
     if args.rank != 0:
         # Workers return here

--- a/examples/hf/gpt2/pippy_gpt2.py
+++ b/examples/hf/gpt2/pippy_gpt2.py
@@ -57,7 +57,7 @@ def calc_flop(args, conf):
     return 96 * B * s * l * h * h * (1 + s/6/h + V/16/l/h)
 
 
-def run_master(_, args):
+def run_gspmd(_, args):
     print(args)
     MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.REPLICATE if args.replicate else MultiUseParameterConfig.TRANSMIT
     assert args.world_size >= 4, "This program requires at least 3 workers + 1 master"
@@ -89,10 +89,6 @@ def run_master(_, args):
     batch_size = args.batch_size * chunks
     vocab_size = gpt2.config.vocab_size
 
-    FLOP = calc_flop(args, config)
-
-    print(f"FLOP per iteration {FLOP}")
-
     device = args.device
     print("Using device:", device)
 
@@ -116,8 +112,17 @@ def run_master(_, args):
     gpt2_pipe = Pipe.from_tracing(gpt2, MULTI_USE_PARAM_CONFIG, tracer=PiPPyHFTracer(), concrete_args=concrete_args,
                                   output_loss_value_spec=output_loss_value_spec, deep_copy_module=False)
     assert sm_cnt == len(list(gpt2_pipe.split_gm.children()))
-    if args.mode == 'small':
+
+    # Materialize model differently depending on run mode
+    if args.gspmd == 1:
+        print(f"Deferring stage init on device {device}")
+        gpt2_pipe.defer_stage_init(device)
+    else:
         gpt2_pipe.to(device)
+
+    if args.rank != 0:
+        # Workers return here
+        return
 
     # gpt2_pipe(**gpt2_input_dict)
 
@@ -128,17 +133,13 @@ def run_master(_, args):
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'labels': TensorChunkSpec(0), 'position_ids': None}
     output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0),
                          'past_key_values': [[TensorChunkSpec(0) for _ in range(2)] for _ in range(config.n_layer)]}
-    if args.mode == 'large-cpu':
-        intermediate_device = device
-    else:
-        intermediate_device = None
     pipe_driver: PipelineDriverBase = schedules[args.schedule](gpt2_pipe, chunks, args_chunk_spec, kwargs_chunk_spec,
                                                                output_chunk_spec, len(all_worker_ranks),
                                                                all_ranks=all_worker_ranks,
                                                                _debug_mask_minibatches=False,
                                                                _record_mem_dumps=bool(args.record_mem_dumps),
                                                                checkpoint=bool(args.checkpoint),
-                                                               device=intermediate_device)
+                                                              )
 
     this_file_name = os.path.splitext(os.path.basename(__file__))[0]
 
@@ -147,6 +148,8 @@ def run_master(_, args):
         for i in range(args.warmup_batches):
             pipe_driver(**gpt2_input_dict)
 
+    FLOP = calc_flop(args, config)
+    print(f"FLOP per iteration {FLOP}")
     print(f'Running GPT-2 pipeline {args.batches} batches for TFLOP/s/GPU measurement.')
 
     start = time.time()
@@ -196,8 +199,8 @@ if __name__ == "__main__":
     parser.add_argument('--n_layer', type=int, default=None)
     parser.add_argument('--n_head', type=int, default=None)
 
-    parser.add_argument('--mode', type=str, default='small', choices=['small', 'large-cpu'])
+    parser.add_argument('--gspmd', type=int, default=0, choices=[0, 1])
 
     args = parser.parse_args()
 
-    run_pippy(run_master, args)
+    run_pippy(run_gspmd, args)

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -202,13 +202,13 @@ def run_worker(rank, run_func, args, *extra_args):
             )
 
     else:
-        args.pp_group = torch.distributed.new_group(my_pp_ranks)
+        pp_group = torch.distributed.new_group(my_pp_ranks)
 
         def pp_group_barrier():
             logging.debug(
                 f"Running pipeline group barrier on ranks {my_pp_ranks}"
             )
-            torch.distributed.barrier(args.pp_group)
+            torch.distributed.barrier(pp_group)
 
     if rank >= 0 and rank // args.dp_group_size == 0:
         args.driver_index = rank

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -196,6 +196,6 @@ def run_worker(rank, run_func, args, *extra_args):
         args.local_driver_index = os.getenv("LOCAL_RANK", rank)
         run_func(pp_ranks_per_dp_group[rank], args, *extra_args)
     elif gspmd == 1:
-        run_func([], args, *extra_args)
+        run_func(pp_ranks_per_dp_group[rank % args.dp_group_size], args, *extra_args)
 
     rpc.shutdown()

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -174,10 +174,6 @@ def run_worker(rank, run_func, args, *extra_args):
         for rank in range(args.dp_group_size)
     ]
 
-    args.pp_group = torch.distributed.new_group(
-        pp_ranks_per_dp_group[rank % args.dp_group_size]
-    )
-
     args.driver_group = torch.distributed.new_group(
         list(range(args.dp_group_size))
     )
@@ -189,6 +185,11 @@ def run_worker(rank, run_func, args, *extra_args):
     gspmd = (  # type: ignore[name-defined]
         args.gspmd if hasattr(args, "gspmd") else 0
     )
+
+    if gspmd:
+        args.pp_group = torch.distributed.new_group(
+            pp_ranks_per_dp_group[rank % args.dp_group_size]
+        )
 
     if rank >= 0 and rank // args.dp_group_size == 0:
         args.driver_index = rank

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -174,6 +174,10 @@ def run_worker(rank, run_func, args, *extra_args):
         for rank in range(args.dp_group_size)
     ]
 
+    args.pp_group = torch.distributed.new_group(
+        pp_ranks_per_dp_group[rank % args.dp_group_size]
+    )
+
     args.driver_group = torch.distributed.new_group(
         list(range(args.dp_group_size))
     )

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -188,14 +188,27 @@ def run_worker(rank, run_func, args, *extra_args):
         args.gspmd if hasattr(args, "gspmd") else 0
     )
 
-    args.pp_group = torch.distributed.new_group(my_pp_ranks)
-
     # A barrier util for pipeline dimension
     global pp_group_barrier
 
-    def pp_group_barrier():
-        logging.debug(f"Running pipeline group barrier on ranks {my_pp_ranks}")
-        torch.distributed.barrier(args.pp_group)
+    # ProcessGroupGloo cannot create group with strided ranks, e.g. [0, 2, 4, 6, ...]
+    # Skipping the `pp_group` and `pp_group_barrier` creation here
+    # TODO: unskip
+    if torch.distributed.get_backend() == "gloo" and args.dp_group_size > 1:
+
+        def pp_group_barrier():
+            logging.warning(
+                f"pp_group_barrier() does not support ProcessGroupGloo with strided ranks {my_pp_ranks}. This will be a no-op."
+            )
+
+    else:
+        args.pp_group = torch.distributed.new_group(my_pp_ranks)
+
+        def pp_group_barrier():
+            logging.debug(
+                f"Running pipeline group barrier on ranks {my_pp_ranks}"
+            )
+            torch.distributed.barrier(args.pp_group)
 
     if rank >= 0 and rank // args.dp_group_size == 0:
         args.driver_index = rank


### PR DESCRIPTION
- Migrate GPT2 example to use the GSPMD based deferred init mode
- Remove "device" argument from PipelineDriver
- Add `pippy.utils.pp_group_barrier()` to avoid race causing "is not deferred" issue