### PR TITLE
Fix SPMD expansion and test_tracing.py

### DIFF
--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -467,7 +467,7 @@ class _SPMD:
                     schemas.append(shard_schema)
 
         parallelized_gm, output_specs = _convert_to_distributed(
-            training_phase, gm, inps, schemas
+            training_phase, gm, inps, schemas, _allow_partial=False,
         )
         self._known_specs_by_node_name.update(output_specs)
 

--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -467,7 +467,11 @@ class _SPMD:
                     schemas.append(shard_schema)
 
         parallelized_gm, output_specs = _convert_to_distributed(
-            training_phase, gm, inps, schemas, _allow_partial=False,
+            training_phase,
+            gm,
+            inps,
+            schemas,
+            _allow_partial=False,
         )
         self._known_specs_by_node_name.update(output_specs)
 


### PR DESCRIPTION
Turns out that our unit tests were not properly testing SPMD because we had the same random_seed set on all ranks which means all parameters and inputs were the same. After setting different random seeds on each rank, the tests started failing, but then passed again after fixed a bug in distribute.py (we were not adding the collectives at the end because we were passing _allow_partial=False)