### PR TITLE
graph_optimization: update before validate

### DIFF
--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -40,11 +40,13 @@ def graph_optimization_pass(
             assert (
                 not invalid_passes
             ), f"{invalid_passes} must run after {func.__name__}"
+            self.graph.update()
             self.graph.validate()
 
             ret = func(self.graph, *args, **kwargs)
 
             assert self.graph == ret
+            self.graph.update()
             self.graph.validate()
             self._optimized_func.add(func.__name__)
             return self


### PR DESCRIPTION
this behavior was not tested;
for some reason, when running Rich's unit tests, the backward graphs are already present -- most likely because we run forward a second time?