### PR TITLE
create individual seed per gpu to ensure meaningful all_reduce work

### DIFF
--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -104,7 +104,9 @@ class ReplicaModel(nn.Module):
 
 
 def work_main(rank: int, world_size: int) -> None:
-    torch.manual_seed(10)
+    # must randomize the seed per GPU to ensure all_reduce
+    # is meaningful.
+    torch.manual_seed(rank)
 
     _device_type = "cuda" if torch.cuda.is_available() else "cpu"
 


### PR DESCRIPTION
Per Alisson's finding in our unit tests, I've updated the seeding to be distinct per gpu to ensure randomized inputs.
This ensures meaningful all_reduces for the various models. 