### PR TITLE
clone node offset, fix node issue from deepcopy, add autodepth finder for comm node

### DIFF
--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -86,6 +86,8 @@ class GraphInfo:
     first: Optional[fx.Node] = None
     # last node in graph (tail / output)
     output: Optional[fx.Node] = None
+    # offset to comm node within a FusionElement sequence
+    fe_offset_to_comm_node: Optional[int] = None
 
     def update_info(self, gm: fx.GraphModule) -> None:
         """Get the len, input and output nodes"""
@@ -155,6 +157,7 @@ def _insert_fusion_buffer_node(
 
 
 def _scan_graph_for_fusion_elements(
+    gi: GraphInfo,
     gm: fx.GraphModule,
     comm_type: CommType = CommType.allreduce,
 ) -> Optional[List[FusionElement]]:
@@ -177,8 +180,16 @@ def _scan_graph_for_fusion_elements(
     fe_size = len(fe_sequence) - 1
     index = 0
     curr_node_list = []
-    # depth to reach comm_node, adjust based on clone presence
-    offset_to_comm_node = 3
+
+    # depth to reach comm_node
+    if gi.fe_offset_to_comm_node is None:
+        for depth, item in enumerate(fe_sequence):
+            if isinstance(item, CommType):
+                gi.fe_offset_to_comm_node = depth
+                break
+    assert (
+        gi.fe_offset_to_comm_node is not None
+    ), f"Unable to locate comm node in {fe_sequence}."
 
     for i, node in enumerate(gm.graph.nodes):
         pattern = fe_sequence[index]
@@ -208,7 +219,7 @@ def _scan_graph_for_fusion_elements(
 
                 fe.output_name = node.name
                 fe.wait_node = node
-                fe.comm_node = curr_node_list[offset_to_comm_node]
+                fe.comm_node = curr_node_list[gi.fe_offset_to_comm_node]
 
                 fe.grad_tensor_node = fe.comm_node.args[0][0]  # type: ignore
 
@@ -589,7 +600,9 @@ def run_comm_fusion(gm: fx.GraphModule) -> None:
     _debug(f"\n Start of fusion pass graph {gm.graph.print_tabular()}\n")
 
     # scan graph for all comm sections (fusion elements)
-    fe_list = _scan_graph_for_fusion_elements(gm, comm_type=CommType.allreduce)
+    fe_list = _scan_graph_for_fusion_elements(
+        graph_info, gm, comm_type=CommType.allreduce
+    )
 
     graph_info.num_starting_fe = len(fe_list)  # type: ignore
     graph_info.fe_list = fe_list

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -219,7 +219,7 @@ def _scan_graph_for_fusion_elements(
 
                 fe.output_name = node.name
                 fe.wait_node = node
-                fe.comm_node = curr_node_list[gi.fe_offset_to_comm_node]
+                fe.comm_node = curr_node_list[gi.fe_offset_to_comm_node]  # type: ignore
 
                 fe.grad_tensor_node = fe.comm_node.args[0][0]  # type: ignore
 


### PR DESCRIPTION
This PR is to update two aspects:
1 - rollback the changes that assumed clone nodes would not be present 
2 - fix a tricky bug from using deepcopy for the fe node list. 
3 - adds automatic offset finder for the comm node to replace the hardcoded offset within the FusionElement node list. 

Note - unit test is pending, but needs some further integration work for the new api/distributed breakout. Wanted to get the above fixes in directly.  
This file with changes is not live/hooked in yet to be clear. 