### PR TITLE
[SPMD] Fix the import path to the functorch internal code

### DIFF
--- a/spmd/compiler/aot_function_patch.py
+++ b/spmd/compiler/aot_function_patch.py
@@ -1,4 +1,4 @@
-from functorch._src.aot_autograd import (
+from torch._functorch.aot_autograd import (
     default_partition,
     AOTConfig,
     AOT_COUNTER,

--- a/spmd/compiler/aot_function_patch.py
+++ b/spmd/compiler/aot_function_patch.py
@@ -109,7 +109,7 @@ def patched_aot_function(
         bw_compiler=bw_compiler,
         partition_fn=partition_fn,
         # pyre-fixme
-        decompositions=decompositions,
+        decompositions=decompositions,  # type:ignore[arg-type]
         num_params_buffers=num_params_buffers,
         aot_id=next(AOT_COUNTER),
     )

--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -35,7 +35,7 @@ from .log_utils import rank0_info
 
 # patch aot_function so that we can pass the full (non-sharded) input to capture the graph
 # pyre-fixme
-functorch._src.aot_autograd.aot_function = patched_aot_function
+torch._functorch.aot_autograd.aot_function = patched_aot_function
 
 
 logger: logging.Logger = logging.getLogger(__name__)

--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -4,8 +4,6 @@ from enum import auto, Enum
 from functools import partial
 from typing import cast, Dict, List, Sequence, Set, Tuple
 
-import functorch.compile
-
 import torch
 import torch.fx as fx
 import torch.nn as nn


### PR DESCRIPTION
Functorch internal code has been moved to a different place. This PR fixes the path to import the functorch internal code.