### PR TITLE
[SPMD] Ensure optimized is set to True after optimizations are applied

### DIFF
--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -128,6 +128,9 @@ class DistGraphOptimization:
                 self, **optim.kwargs
             )
             assert _self == self
+
+        self._optimizing = False
+        self._optimized = True
         return self
 
     @graph_optimization_pass()

--- a/test/spmd/compiler/test_graph_optimizations.py
+++ b/test/spmd/compiler/test_graph_optimizations.py
@@ -96,6 +96,9 @@ class CommOverlapTest(DTensorTestBase):
         spmd_overlap(input).sum().backward()
         ddp_model(input).sum().backward()
 
+        self.assertTrue(spmd_overlap._graph_optimization.optimized)
+        self.assertFalse(spmd_overlap._graph_optimization._optimizing)
+
         # compare overlap vs DDP
         for i, (p1, p2) in enumerate(
             zip(ddp_model.parameters(), spmd_overlap.parameters())


### PR DESCRIPTION
Right now the `optimized` flag is not appropriately set. This PR fixes the issue.