### PR TITLE
Ring fusion - adds overlapped comm fusion for SPMD using a ring buffer

### DIFF
--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 21
+    layers = 4
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)
@@ -130,9 +130,9 @@ def work_main(rank: int, world_size: int) -> None:
     run_backward = True
     all_spmd = []
     optimizations = [
-        [GraphOptimization("fuse_communication")],
-        [GraphOptimization("fuse_communication_cat")],
-        [GraphOptimization("overlap_communication")],
+        [GraphOptimization("fuse_communication_ring")],
+        # [GraphOptimization("fuse_communication_cat")],
+        # [GraphOptimization("overlap_communication")],
     ]
     for optim in optimizations:
         spmd = SPMD(

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 8
+    layers = 4
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 4
+    layers = 8
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -288,7 +288,7 @@ def _copy_fe_to_buffer(
         "_tensor_constant"
     ), f"failed to locate tensor constant node {constant_list[1]}"
 
-    for item in copy_list:
+    for item in constant_list:
         curr_node.append(item)
         curr_node = curr_node.next
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -202,7 +202,7 @@ def _insert_fusion_buffer_node(
     ), f"failed to create buffer node, size={buffer_size}"
 
     # init ring buffer
-    gi.setup_ring_buffer(ring_buffer, buffer_size)
+    gi.setup_ring_buffer(ring_buffer, buffer_size)  # type: ignore
 
     return ring_buffer
 
@@ -335,7 +335,7 @@ def _copy_fe_to_buffer(
 
     # move clone nodes
     curr_node = source_node
-    for item in all_grad_nodes:
+    for item in all_grad_nodes:  # type: ignore
         if curr_node is not item:
             curr_node.append(item)
         curr_node = curr_node.next
@@ -352,7 +352,7 @@ def _copy_fe_to_buffer(
         "_tensor_constant"
     ), f"failed to locate tensor constant node {constant_list[1]}"
 
-    for item in constant_list:
+    for item in constant_list:  # type: ignore
         curr_node.append(item)
         curr_node = curr_node.next
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -373,10 +373,10 @@ def _copy_fe_to_buffer(
 
     _update_new_copy_nodes_users(value_remap)
 
-    gm.recompile()
-    _debug(
-        f"381 =====after clone, tensor_constant and allreduce insert =====\n {gm.graph.print_tabular()}\n"
-    )
+    # gm.recompile()
+    # _debug(
+    #    f"381 =====after clone, tensor_constant and allreduce insert =====\n {gm.graph.print_tabular()}\n"
+    # )
 
 
 def _build_buffer_comm_graph(
@@ -601,7 +601,7 @@ def _finalize_output_node(
 
     # map out all updated nodes in our list
     # working in reverse for fusion, so undo for simple replacement
-    fe_list = fe_list[::-1]
+    # fe_list = fe_list[::-1]
     for item in fe_list:
         grad_node = item.grad_tensor_node
         wait_node = item.wait_node
@@ -672,7 +672,7 @@ def _teardown(gm: fx.GraphModule) -> None:
 def run_fuse_communication_ring(
     gm: fx.GraphModule,
     fusion_policy: int = 2,
-    ring_buffer_size: int = 2,
+    ring_buffer_size: int = 4,
 ) -> None:
     """rewrite to deal with out of order clone nodes"""
 
@@ -755,7 +755,7 @@ def run_fuse_communication_ring(
 
     _debug(f"Final output node args {new_output_args=}\n")
 
-    _debug(f"Final graph 757 {print(gm.graph)}")
+    # _debug(f"Final graph 757 {print(gm.graph.print_tabular())}")
 
     rebuild_graph(gm)
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -729,7 +729,6 @@ def run_fuse_communication_ring(
         if node in actual_gradients:
             graph_info.actual_grad_index_mapping[node] = idx
 
-    _debug(f"start main loop")
     # Main processing loop
     for start in range(0, len(graph_info.fe_list), fusion_length):
         stop = start + fusion_length

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -336,7 +336,7 @@ def _copy_fe_to_buffer(
     # move clone nodes
     curr_node = source_node
     for item in all_grad_nodes:  # type: ignore
-        if curr_node is not item:
+        if curr_node.next is not item:
             curr_node.append(item)
         curr_node = curr_node.next
 
@@ -729,6 +729,7 @@ def run_fuse_communication_ring(
         if node in actual_gradients:
             graph_info.actual_grad_index_mapping[node] = idx
 
+    _debug(f"start main loop")
     # Main processing loop
     for start in range(0, len(graph_info.fe_list), fusion_length):
         stop = start + fusion_length
@@ -753,7 +754,7 @@ def run_fuse_communication_ring(
 
     _debug(f"\nRing Comm Fusion processed {len(fe_list)} fe items\n")
 
-    _debug(f"Final output node args {new_output_args=}\n")
+    # _debug(f"Final output node args {new_output_args=}\n")
 
     rebuild_graph(gm)
 

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, DefaultDict, Dict, Iterable, Sequence, Set
 from .bucketing_strategies import BucketingStrategy
 from .distributed_graph import DistributedGraph
 from .fusion import (
-    run_fuse_communication,
+    run_fuse_communication_ring,
     run_fuse_communication_cat,
     run_overlap_communication,
 )
@@ -24,7 +24,7 @@ _run_before_sets: DefaultDict[str, Set[str]] = defaultdict(set)
 class GraphOptimizationType(str, Enum):
     NOOP = "noop"
     OVERLAP_COMMUNICATION = "overlap_communication"
-    FUSE_COMMUNICATION = "fuse_communication"
+    FUSE_COMMUNICATION_RING = "fuse_communication_ring"
     FUSE_COMMUNICATION_CAT = "fuse_communication_cat"
 
 
@@ -166,18 +166,20 @@ class DistGraphOptimization:
         return self
 
     @graph_optimization_pass()
-    def fuse_communication(
+    def fuse_communication_ring(
         self,
         bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
         scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
-        fusion_policy: int = 10,
+        fusion_policy: int = 2,
     ) -> "DistGraphOptimization":
 
         assert len(
             self._graph.bwd_graph_modules
         ), f"no bwd graph ready from {self._graph.bwd_graph_modules}"
 
-        run_fuse_communication(self._graph.bwd_graph_modules[0], fusion_policy)
+        run_fuse_communication_ring(
+            self._graph.bwd_graph_modules[0], fusion_policy
+        )
         return self
 
     @graph_optimization_pass()

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -170,7 +170,7 @@ class DistGraphOptimization:
         self,
         bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
         scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
-        fusion_policy: int = 2,
+        # fusion_policy: int = 2,
     ) -> "DistGraphOptimization":
 
         assert len(
@@ -178,7 +178,7 @@ class DistGraphOptimization:
         ), f"no bwd graph ready from {self._graph.bwd_graph_modules}"
 
         run_fuse_communication_ring(
-            self._graph.bwd_graph_modules[0], fusion_policy
+            self._graph.bwd_graph_modules[0]  # , fusion_policy
         )
         return self
 

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -170,7 +170,8 @@ class DistGraphOptimization:
         self,
         bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
         scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
-        # fusion_policy: int = 2,
+        fusion_length: int = 2,
+        ring_buffer_size: int = 2,
     ) -> "DistGraphOptimization":
 
         assert len(
@@ -178,7 +179,9 @@ class DistGraphOptimization:
         ), f"no bwd graph ready from {self._graph.bwd_graph_modules}"
 
         run_fuse_communication_ring(
-            self._graph.bwd_graph_modules[0]  # , fusion_policy
+            self._graph.bwd_graph_modules[0],
+            fusion_length,
+            ring_buffer_size,
         )
         return self
 


### PR DESCRIPTION
This PR adds overlapped fusion using a ring buffer.
It has two params:
a - fusion_policy which is the total number of comm calls to fuse (i.e. 60 = fuse 60 calls into 1)
b - buffer_policy, which controls how many unique buffers to have in the ring.  Buffers are handed out in a cycle
to each respective fusion operation. 
The reason for the cycling is to avoid overwriting the buffer - we do not mutex the buffer, and comms are asynch.
Thus we can have a situation where a new fusion starts writing into an existing buffer before the outputs from the previous call are copied out.  
