### PR TITLE
update optimization name to fuse_communication_ring

### DIFF
--- a/test/spmd/compiler/test_graph_optimizations.py
+++ b/test/spmd/compiler/test_graph_optimizations.py
@@ -74,7 +74,7 @@ class CommOverlapTest(DTensorTestBase):
         optimizations = [
             [],
             [GraphOptimization("overlap_communication")],
-            [GraphOptimization("fuse_communication")],
+            [GraphOptimization("fuse_communication_ring")],
             [GraphOptimization("fuse_communication_cat")],
         ]
         for optim in optimizations:


### PR DESCRIPTION
I updated the name for fuse_communication to fuse_communication_ring in order to match 'fuse_communication_cat'.
This PR updates the unit testing to the updated name. 