### PR TITLE
Fix device buffer

### DIFF
--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -94,7 +94,7 @@ def _get_dtensor_dispatch_graph(
     def remap_arg(arg: object) -> object:
         if isinstance(arg, torch.fx.Node):
             obj = node_to_obj[arg]
-            if _get_tracer(obj):
+            if _get_tracer():
                 # This is a shared arg, already has a tracer from previous
                 # tracing. Delete the tracer.
                 del cast(Dict[object, object], obj.__dict__)[proxy_slot]
@@ -435,7 +435,7 @@ def _convert_to_distributed(
                     # TODO(anj): we need this for getitem but can we be more generic?
                     if isinstance(obj, tuple):
                         return obj
-                    if _get_tracer(obj):
+                    if _get_tracer():
                         # This is a shared arg, already has a tracer from previous
                         # tracing. Delete the tracer.
                         del cast(Dict[object, object], obj.__dict__)[proxy_slot]

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import cast, Dict, List, Optional, Tuple
 
 import torch
-import torch.distributed as dist
 import torch.fx as fx
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.passes.shape_prop import TensorMetadata

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -177,13 +177,11 @@ def _create_fusion_buffers(
         insert_before_node = node
         break
 
-    # TODO - fix with correct rank - needs to match with higher DTensor device
-
-    rank = dist.get_rank()
+    """rank = dist.get_rank()
     if torch.distributed.is_initialized():
         torch.cuda.set_device(rank)
     rank_device = torch.cuda.current_device()
-
+    """
     ring_buffer = []
     new_buffer_node = None
     with gm.graph.inserting_before(insert_before_node):
@@ -191,9 +189,8 @@ def _create_fusion_buffers(
             new_buffer_node = gm.graph.create_node(
                 OP.CALL_FUNCTION,
                 target=torch.empty,
-                # TODO - need device from DTensor to put buffer on gpu
                 args=(buffer_size,),
-                kwargs={"device": rank_device},
+                kwargs={"device": "cuda"},
             )
             ring_buffer.append(new_buffer_node)
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -171,17 +171,14 @@ def _create_fusion_buffers(
     appends to GlobalInfo if passed in"""
 
     # default to inserting just after last placeholder node
+    # TODO - more efficient if we drop the buffer right before first use
+    # to reduce memory pressure.
     for node in gm.graph.nodes:
         if node.op == OP.PLACEHOLDER:
             continue
         insert_before_node = node
         break
 
-    """rank = dist.get_rank()
-    if torch.distributed.is_initialized():
-        torch.cuda.set_device(rank)
-    rank_device = torch.cuda.current_device()
-    """
     ring_buffer = []
     new_buffer_node = None
     with gm.graph.inserting_before(insert_before_node):

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -180,6 +180,9 @@ def _create_fusion_buffers(
 
     ring_buffer = []
     new_buffer_node = None
+    # there is an assumption below that torch.set_device has been setup by
+    # DTensor.  We thus ride on that by passing "cuda" for device, which
+    # should expand internally to "cuda:index".
     with gm.graph.inserting_before(insert_before_node):
         for i in range(ring_size):
             new_buffer_node = gm.graph.create_node(

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -171,7 +171,7 @@ class DistGraphOptimization:
         bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
         scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
         fusion_length: int = 2,
-        ring_buffer_size: int = 2,
+        ring_num_buffers: int = 2,
     ) -> "DistGraphOptimization":
 
         assert len(
@@ -181,7 +181,7 @@ class DistGraphOptimization:
         run_fuse_communication_ring(
             self._graph.bwd_graph_modules[0],
             fusion_length,
-            ring_buffer_size,
+            ring_num_buffers,
         )
         return self
 


### PR DESCRIPTION
This PR: 
1 - moves the buffer creation from using "rank" to the universal "cuda" to match DTensor and fix multi-node support. 
It also makes a naming synch between fusion and graph_optimization to be consistent with param ring_num_buffers for the total buffer count.
2 - unrelated but proactive fix - the _get_tracer() call in CommTensor no longer takes an obj.  Have thus updated param signature to match in distribute.py.  

