### PR TITLE
Remove requirement for loss spec

### DIFF
--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -165,18 +165,14 @@ def transform_into_pipeline(
     chunks: int = 1,
     all_worker_ranks: List[int] = None,
 ):
-    output_loss_value_spec = {
-        "loss": True,
-        "logits": False,
-        "encoder_last_hidden_state": False,
-    }
+    if not args.train:
+        model.eval()
 
     t5_pipe = Pipe.from_tracing(
         model,
         multi_use_param_spec,
         tracer=PiPPyHFTracer(),
         concrete_args=concrete_args,
-        output_loss_value_spec=output_loss_value_spec if args.train else None,
         split_policy=split_policy,
     )
 

--- a/examples/hf/t5/pippy_wrapper.sh
+++ b/examples/hf/t5/pippy_wrapper.sh
@@ -10,6 +10,4 @@ export RANK=${SLURM_PROCID}
 
 python -u pippy_t5.py \
   --model_config=t5_3b_config.json \
-  --record_mem_dumps=0 \
-  --batches=2 \
   --checkpoint=1

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -944,11 +944,17 @@ class Pipe(torch.nn.Module):
                 mod, split.graph, output_loss_value_spec
             )
             if loss_node is not None:
-                _insert_stage_symbolic_backward(split.graph, loss_node, output_node)
+                _insert_stage_symbolic_backward(
+                    split.graph, loss_node, output_node
+                )
                 split.recompile()
                 has_loss_and_backward = True
             else:
-                logging.info("Did not find any loss value, thus not creating backward pass.")
+                logging.warning(
+                    "Did not find any loss value from model output, your pipeline will be in inference mode. "
+                    "If you want your pipeline to be in training mode, please specify a loss value via "
+                    "`output_loss_value_spec`."
+                )
 
         return Pipe(split, qualname_map, num_stages, has_loss_and_backward)
 

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -86,20 +86,18 @@ def _find_loss_from_output_and_spec(output_val, spec_val):
 
     if spec_val is None:
         # Use default spec, i.e. search for "loss" in output values
-        if (isinstance(output_val, dict) and
-            "loss" in output_val.keys()
-        ):
+        if isinstance(output_val, dict) and "loss" in output_val.keys():
             return output_val["loss"]
-        raise RuntimeError(
-            f"Did not find 'loss' in output dict"
-        )
+        raise RuntimeError(f"Did not find 'loss' in output dict")
 
     raise RuntimeError(
         f"Unsupported type {type(spec_val)} in loss specification"
     )
 
 
-def _find_loss_output(mod: torch.nn.Module, g: pippy.fx.Graph, output_loss_value_spec):
+def _find_loss_output(
+    mod: torch.nn.Module, g: pippy.fx.Graph, output_loss_value_spec
+):
     output_nodes = [n for n in g.nodes if n.op == "output"]
     assert len(output_nodes) == 1
     output_node = output_nodes[0]
@@ -115,7 +113,9 @@ def _find_loss_output(mod: torch.nn.Module, g: pippy.fx.Graph, output_loss_value
     return loss_node, output_node
 
 
-def _insert_stage_symbolic_backward(g: pippy.fx.Graph, loss_node: pippy.fx.Node, output_node: pippy.fx.Node):
+def _insert_stage_symbolic_backward(
+    g: pippy.fx.Graph, loss_node: pippy.fx.Node, output_node: pippy.fx.Node
+):
     # Collect metadata about tuple output values. TODO: move this to split_module or FX IR
     tuples: Dict[pippy.fx.Node, Tuple] = {}
     for node in reversed(g.nodes):
@@ -939,7 +939,9 @@ class Pipe(torch.nn.Module):
         has_loss_and_backward = False
 
         if mod.training:
-            loss_node, output_node = _find_loss_output(mod, split.graph, output_loss_value_spec)
+            loss_node, output_node = _find_loss_output(
+                mod, split.graph, output_loss_value_spec
+            )
             _insert_stage_symbolic_backward(split.graph, loss_node, output_node)
             split.recompile()
             has_loss_and_backward = True

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -88,7 +88,8 @@ def _find_loss_from_output_and_spec(output_val, spec_val):
         # Use default spec, i.e. search for "loss" in output values
         if isinstance(output_val, dict) and "loss" in output_val.keys():
             return output_val["loss"]
-        raise RuntimeError(f"Did not find 'loss' in output dict")
+        else:
+            return None
 
     raise RuntimeError(
         f"Unsupported type {type(spec_val)} in loss specification"
@@ -942,9 +943,12 @@ class Pipe(torch.nn.Module):
             loss_node, output_node = _find_loss_output(
                 mod, split.graph, output_loss_value_spec
             )
-            _insert_stage_symbolic_backward(split.graph, loss_node, output_node)
-            split.recompile()
-            has_loss_and_backward = True
+            if loss_node is not None:
+                _insert_stage_symbolic_backward(split.graph, loss_node, output_node)
+                split.recompile()
+                has_loss_and_backward = True
+            else:
+                logging.info("Did not find any loss value, thus not creating backward pass.")
 
         return Pipe(split, qualname_map, num_stages, has_loss_and_backward)
 

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -84,24 +84,37 @@ def _find_loss_from_output_and_spec(output_val, spec_val):
             f"Did not find loss value in specification {spec_val}"
         )
 
+    if spec_val is None:
+        # Use default spec, i.e. search for "loss" in output values
+        if (isinstance(output_val, dict) and
+            "loss" in output_val.keys()
+        ):
+            return output_val["loss"]
+        else:
+            return None
+
     raise RuntimeError(
         f"Unsupported type {type(spec_val)} in loss specification"
     )
 
 
-def _insert_stage_symbolic_backward(g: pippy.fx.Graph, output_loss_value_spec):
+def _check_for_loss_output(mod: torch.nn.Module, g: pippy.fx.Graph, output_loss_value_spec):
     output_nodes = [n for n in g.nodes if n.op == "output"]
     assert len(output_nodes) == 1
     output_node = output_nodes[0]
 
-    if output_loss_value_spec:
+    if isinstance(mod, LossWrapper):
+        assert len(output_node.args) == 1
+        loss_node = output_node.args[0]
+    else:
         loss_node = _find_loss_from_output_and_spec(
             output_node.args[0], output_loss_value_spec
         )
-    else:
-        assert len(output_node.args) == 1
-        loss_node = output_node.args[0]
 
+    return loss_node, output_node
+
+
+def _insert_stage_symbolic_backward(g: pippy.fx.Graph, loss_node: pippy.fx.Node, output_node: pippy.fx.Node):
     # Collect metadata about tuple output values. TODO: move this to split_module or FX IR
     tuples: Dict[pippy.fx.Node, Tuple] = {}
     for node in reversed(g.nodes):
@@ -922,8 +935,10 @@ class Pipe(torch.nn.Module):
 
         num_stages = Pipe._number_and_count_forward_stages(split)
 
-        if isinstance(mod, LossWrapper) or output_loss_value_spec:
-            _insert_stage_symbolic_backward(split.graph, output_loss_value_spec)
+        loss_node, output_node = _check_for_loss_output(mod, split.graph, output_loss_value_spec)
+
+        if loss_node is not None:
+            _insert_stage_symbolic_backward(split.graph, loss_node, output_node)
             split.recompile()
             has_loss_and_backward = True
         else:


### PR DESCRIPTION
Previously, we require users to provide a one-hot map to specify which output value is the loss.
For example, for T5:
```
    output_loss_value_spec = {
        "loss": True,
        "logits": False,
        "encoder_last_hidden_state": False,
    }
```
This requires users to have a good understanding of the model.

With this PR, we try to free users from such specification. We do so by automatically searching for "loss" in the output dict. (This is the most prevalent format for Hugging Face models.) 

Previously, `output_loss_value_spec=None` has been used to indicate the inference mode. Now, to do the same, users can set the model to evaluate mode before passing it to PiPPy. That is,
```
model.eval()
pipe = Pipe.from_tracing(model, ...)
```