### PR TITLE
Fix PiPPy + Dynamo CI

### DIFF
--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -252,8 +252,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
+      - name: Install TorchDynamo
+        run: pip install git+https://github.com/pytorch/torchdynamo.git@main torchdynamo
       - name: Install pippy
         run: "python setup.py install"
       - name: Test PiPPy + Dynamo example

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -252,6 +252,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install numpy
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
       - name: Install pippy
         run: "python setup.py install"

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -253,8 +253,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt --find-links https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html; fi
-      - name: Install TorchDynamo
-        run: pip install git+https://github.com/pytorch/torchdynamo.git@main torchdynamo
       - name: Install pippy
         run: "python setup.py install"
       - name: Test PiPPy + Dynamo example

--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -10,6 +10,7 @@ import torch.fx
 # TorchDynamo is moved into PyTorch for PyTorch > 1.13
 # One can use TorchDynamo without installing it separately by:
 import torch._dynamo as dynamo
+# If your PyTorch version is <= 1.13.0, please install torchdynamo separately
 # import torchdynamo as dynamo
 
 import pippy.fx

--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -9,9 +9,9 @@ import torch.autograd.profiler_legacy
 import torch.fx
 # TorchDynamo is moved into PyTorch for PyTorch > 1.13
 # One can use TorchDynamo without installing it separately by:
-import torch._dynamo as dynamo
+# import torch._dynamo as dynamo
 # If your PyTorch version is <= 1.13.0, please install torchdynamo separately
-# import torchdynamo as dynamo
+import torchdynamo as dynamo
 
 import pippy.fx
 from pippy import run_pippy


### PR DESCRIPTION
Fixing CI error encountered after Dynamo upgrade/migration:
https://github.com/pytorch/tau/actions/runs/3816032630/jobs/6491411483

Solution:
updated the way to compute the reference value -- we now move it out of the compilation loop. 

More details: 
it seems `gm` in the compilation loop comes with some Fake components, hence we cannot directly pass `example_inputs` to `gm`.

Effect:
fixed "PiPPy tests / programming_model_tests"