### PR TITLE
[SPMD] Tighten `_is_param` data ptr check

### DIFF
--- a/spmd/compiler/distribute.py
+++ b/spmd/compiler/distribute.py
@@ -480,9 +480,7 @@ class _SPMD:
     def _is_param(self, t: torch.Tensor) -> bool:
         # N.B.: id(t) and id(param) does not match
         orig_module = cast(nn.Module, self._dist_graph.orig_module)
-        return t.storage().data_ptr() in (
-            p.storage().data_ptr() for p in orig_module.parameters()
-        )
+        return t.data_ptr() in (p.data_ptr() for p in orig_module.parameters())
 
     def _map_primal_to_param(
         self, gm: fx.GraphModule, inputs: List[torch.Tensor], nparams: int


### PR DESCRIPTION
I am reading the compiler code, and I noticed something minor with the `_is_param` check. Checking `.storage().data_ptr()` means that views are considered equal. For example:
```
>>> t = torch.randn((3, 3))
>>> t.data_ptr()
94158967421632
>>> t.storage().data_ptr()
94158967421632
>>> s = t[1:]
>>> s.data_ptr()
94158967421644  <-- offset by 12 bytes (3 elements) representing skipping the 0th row
>>> s.storage().data_ptr()
94158967421632  <-- same as that of `t`
```

If I understand correctly, any input to the forward will be represented by an `fx.Node` whose name starts with `primals_`. In that case, if the forward takes in a view of a parameter, then the saved primal mappings may include an extra entry, "double-counting" the parameter, which should trigger the assert in `_map_primal_to_param()`:
https://github.com/pytorch/tau/blob/11a8896707848524b3c0ee20354b319f9f475bc0/spmd/compiler/distribute.py#L498-L501

Ideally, this PR would add a unit test that fails before this change and passes after. However, I am still familiarizing with the code base, so this PR is mainly meant to point this out to the core developers.
