### PR TITLE
JIT fusion, with Memory size fusion policy

### DIFF
--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 5
+    layers = 2
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -32,7 +32,6 @@ def setup(rank: int, world_size: int, use_cuda: bool = True) -> None:
         _debug("--> init process group using nccl")
         dist.init_process_group("nccl", rank=rank, world_size=world_size)
         torch.cuda.set_device(rank)
-        # print(f"--> device set for rank {rank}")
     else:
         _debug("--> init process group using gloo")
         dist.init_process_group("gloo", rank=rank, world_size=world_size)
@@ -119,7 +118,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 5
+    layers = 4
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -32,7 +32,7 @@ def setup(rank: int, world_size: int, use_cuda: bool = True) -> None:
         _debug("--> init process group using nccl")
         dist.init_process_group("nccl", rank=rank, world_size=world_size)
         torch.cuda.set_device(rank)
-        print(f"--> device set for rank {rank}")
+        # print(f"--> device set for rank {rank}")
     else:
         _debug("--> init process group using gloo")
         dist.init_process_group("gloo", rank=rank, world_size=world_size)
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 4
+    layers = 5
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)
@@ -130,8 +130,8 @@ def work_main(rank: int, world_size: int) -> None:
     run_backward = True
     all_spmd = []
     optimizations = [
-        [GraphOptimization("fuse_communication_ring")],
-        # [GraphOptimization("fuse_communication_cat")],
+        # [GraphOptimization("fuse_communication_ring")],
+        [GraphOptimization("fuse_communication_cat")],
         # [GraphOptimization("overlap_communication")],
     ]
     for optim in optimizations:

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -131,7 +131,7 @@ def work_main(rank: int, world_size: int) -> None:
     all_spmd = []
     optimizations = [
         # [GraphOptimization("fuse_communication_ring")],
-        [GraphOptimization("fuse_communication_cat")],
+        [GraphOptimization("fuse_communication_jit")],
         # [GraphOptimization("overlap_communication")],
     ]
     for optim in optimizations:

--- a/examples/spmd/run_spmd.py
+++ b/examples/spmd/run_spmd.py
@@ -119,7 +119,7 @@ def work_main(rank: int, world_size: int) -> None:
     _debug(f"mesh set to {mesh}\n")
 
     # control depth of ReplicaModel
-    layers = 2
+    layers = 5
 
     # model = Permute().to(rank)  #
     model = ReplicaModel(layer_count=layers).to(_device_type)

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1014,6 +1014,10 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
     assert graph_info.output is not None
     new_output_args = list(cast(Tuple[fx.Node], graph_info.output.args[0]))
 
+    
+
+    _map_local_gradients(gm, graph_info, fe_list)
+
     # Fuse every ``fusion_length`` FusionElement.
     for start in range(0, len(graph_info.fe_list), fusion_length):
         _debug(f"fusion indexes = {start=},{start+fusion_length=}")
@@ -1028,8 +1032,6 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
             new_output_args,
             grad_nodes,
         )
-
-    _map_local_gradients(gm, graph_info, fe_list)
 
     # update output with the updated args
     gm.graph.erase_node(graph_info.output)

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -987,7 +987,7 @@ def run_fuse_communication_cat(gm: fx.GraphModule, fusion_length: int) -> None:
 
 
 def _map_local_gradients(
-    gm: fx.GraphModule, graph_info: GraphInfo, fe_list: list[FusionElement]
+    gm: fx.GraphModule, graph_info: GraphInfo, fe_list: List[FusionElement]
 ) -> None:
 
     actual_gradients = set(

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1037,7 +1037,8 @@ def _fuse_with_jit(
     assert copy_list[-1].comm_node is not None
 
     fused_comm_node = copy_list[-1].comm_node
-    fused_comm_node.update_arg(0, [jit_buffer_node])
+
+    fused_comm_node.update_arg(0, [jit_buffer_node])  # type: ignore
 
     fused_comm_node.users[jit_buffer_node] = ""  # type: ignore
 
@@ -1046,7 +1047,7 @@ def _fuse_with_jit(
         fused_comm_node.args[1],
         fused_comm_node.args[2],
         fused_comm_node,
-    ]
+    ]  # type: ignore
 
     insert_node = last_grad_tensor_node.next
     for node in nodes_to_move:

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1021,8 +1021,10 @@ def _fuse_with_jit(
         copy_nodes.append(copy_node)
 
     assert copy_list[-1].comm_node is not None
-    fused_comm_node = copy_list[-1].comm_node
-    fused_comm_node.update_arg(0, [jit_buffer_node])  # type: ignore
+
+    fused_comm_node = cast(fx.Node, copy_list[-1].comm_node)
+    fused_comm_node.update_arg(0, [jit_buffer_node])
+
     fused_comm_node.users[jit_buffer_node] = ""  # type: ignore
 
     # Move the fused_comm_node and its args to right after the source node
@@ -1054,7 +1056,7 @@ def _scatter_results_jit(
 ) -> List[fx.Node]:
 
     assert scatter_list[-1].wait_node is not None
-    wait_node = cast(fx.Node, scatter_list[-1].wait_node)
+    wait_node = scatter_list[-1].wait_node
 
     # ensure user
     wait_user = cast(Tuple[fx.Node], wait_node.args)[0]
@@ -1138,7 +1140,6 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
     new_output_args = list(cast(Tuple[fx.Node], graph_info.output.args[0]))
 
     _map_local_gradients(gm, graph_info, fe_list)
-    _debug(f"1090 local gradients")
 
     # use fusion length as mb instead of count
     start = 0

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1077,7 +1077,7 @@ def _scatter_results_jit(
 
     # ensure user
 
-    wait_user = cast(fx.Node, cast(fx.Node, wait_node).args[0])
+    wait_user = wait_node.args[0]  # type: ignore
     wait_node.users[wait_user] = ""  # type: ignore
 
     scatter_nodes = []

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1158,8 +1158,6 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
                 graph_info, gm, fe_list, jit_buffer_node
             )
 
-            _debug(f"1142, {grad_nodes=}")
-
             _update_output_args(
                 graph_info,
                 gm,
@@ -1186,8 +1184,6 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
             graph_info, gm, fe_list, jit_buffer_node
         )
 
-        _debug(f"1142, {grad_nodes=}")
-
         _update_output_args(
             graph_info,
             gm,
@@ -1196,7 +1192,8 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
             grad_nodes,
         )
 
-    # update output with the updated args
+    # update output with the buffer view args
     gm.graph.erase_node(graph_info.output)
     gm.graph.output(new_output_args)
+
     rebuild_graph(gm, remove_dead_code=True)

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -885,15 +885,6 @@ def _update_output_args(
         output_args[gi.wait_node_idx[fe.wait_node]] = grad_node
 
 
-def run_fuse_comm_cat(gm, fusion_length) -> None:
-    gm.recompile()
-    graph_info = GraphInfo().update_info(gm)
-    fe_list = _scan_graph_for_fusion_elements(
-        graph_info, gm, comm_type=CommType.ALLREDUCE
-    )
-    graph_info.fe_list = fe_list
-
-
 def run_fuse_communication_cat(gm: fx.GraphModule, fusion_length: int) -> None:
     """
     Run fuse communication with concat.
@@ -942,10 +933,8 @@ def run_fuse_communication_cat(gm: fx.GraphModule, fusion_length: int) -> None:
 
     # update output with the updated args
     gm.graph.erase_node(graph_info.output)
-    _debug(f"983, {new_output_args=}\n")
     gm.graph.output(new_output_args)
     rebuild_graph(gm)
-    _debug(f"973 cat {gm.graph.print_tabular()}")
 
 
 def _map_local_gradients(
@@ -1055,7 +1044,7 @@ def _scatter_results_jit(
     scatter_list: List[FusionElement],
     jit_buffer_node: fx.Node,
 ) -> List[fx.Node]:
-    # scatter_sizes = [fe.size for fe in scatter_list]
+
     assert scatter_list[-1].wait_node is not None
     wait_node = scatter_list[-1].wait_node
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1128,21 +1128,21 @@ def _scatter_results_jit(
             (slice_node, shape),
         )
 
-        copy_out_node = gm.graph.call_function(
+        """copy_out_node = gm.graph.call_function(
             torch.ops.aten.copy_.default,
             (fe.grad_tensor_node.args[0], view_node),
         )
+        """
         offset += fe.size
-        # gm.graph.erase_node(fe.grad_tensor_node)
 
         # ensure user for view node
         user = slice_node
         view_node.users[user] = ""  # type: ignore
         # ensure for copy_node
-        user = copy_out_node.args[0]
-        copy_out_node.users[user] = ""
+        # user = copy_out_node.args[0]
+        # copy_out_node.users[user] = ""
 
-        scatter_nodes.extend([slice_node, view_node, copy_out_node])
+        scatter_nodes.extend([slice_node, view_node])
 
         grad_nodes.append(view_node)
 
@@ -1206,7 +1206,7 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
     _debug(f"1153, {new_output_args=}\n")
     gm.graph.erase_node(graph_info.output)
     gm.graph.output(new_output_args)
-    _debug(f"1205 , {print(gm.graph)}\n")
+    # _debug(f"1205 , {print(gm.graph)}\n")
     rebuild_graph(gm, remove_dead_code=True)
     # gm.recompile()
     _debug(f"{print(gm.graph)}\n")

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1036,7 +1036,7 @@ def _fuse_with_jit(
 
     assert copy_list[-1].comm_node is not None
 
-    fused_comm_node = copy_list[-1].comm_node
+    fused_comm_node: fx.Node = copy_list[-1].comm_node
 
     fused_comm_node.update_arg(0, [jit_buffer_node])  # type: ignore
 
@@ -1044,8 +1044,8 @@ def _fuse_with_jit(
 
     # Move the fused_comm_node and its args to right after the source node
     nodes_to_move = jit_inputs + [
-        fused_comm_node.args[1],
-        fused_comm_node.args[2],
+        fused_comm_node.args[1],  # type: ignore
+        fused_comm_node.args[2],  # type: ignore
         fused_comm_node,
     ]  # type: ignore
 
@@ -1077,7 +1077,7 @@ def _scatter_results_jit(
 
     # ensure user
 
-    wait_user = cast(Tuple[fx.Node], wait_node.args)[0]
+    wait_user: fx.Node = cast(Tuple[fx.Node], wait_node.args)[0]
     wait_node.users[wait_user] = ""  # type: ignore
 
     scatter_nodes = []

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1124,9 +1124,7 @@ def _scatter_results_jit(
     return grad_nodes
 
 
-def run_fuse_communication_jit(
-    gm: fx.GraphModule, fusion_length: int, use_MB=False
-) -> None:
+def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
 
     """runs fusion by creating a Just in Time buffer to use for each fusion.
     It then returns views to the buffer for the gradient outputs, avoiding the

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -980,7 +980,7 @@ def _fuse_with_jit(
     gi: GraphInfo, gm: fx.GraphModule, copy_list: List[FusionElement]
 ) -> fx.Node:
 
-    # Find the actual last gradient.
+    # Find the actual last gradient node.
     last_grad_fe_index = _get_last_grad_node_from_fe_group(gi, copy_list)
 
     last_grad_tensor_node = cast(
@@ -1036,7 +1036,7 @@ def _fuse_with_jit(
 
     assert copy_list[-1].comm_node is not None
 
-    fused_comm_node = copy_list[-1].comm_node
+    fused_comm_node = cast(fx.Node, copy_list[-1].comm_node)
     fused_comm_node.update_arg(0, [jit_buffer_node])
 
     fused_comm_node.users[jit_buffer_node] = ""  # type: ignore
@@ -1068,9 +1068,11 @@ def _scatter_results_jit(
     scatter_list: List[FusionElement],
     jit_buffer_node: fx.Node,
 ) -> List[fx.Node]:
+    """prepare views against completed buffer, these will replace gradient nodes for
+    graph output to avoid copy back overhead."""
 
     assert scatter_list[-1].wait_node is not None
-    wait_node = cast(fx.Node, scatter_list[-1].wait_node)
+    wait_node = scatter_list[-1].wait_node
 
     # ensure user
 

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1036,7 +1036,7 @@ def _fuse_with_jit(
 
     assert copy_list[-1].comm_node is not None
 
-    fused_comm_node: fx.Node = copy_list[-1].comm_node
+    fused_comm_node = copy_list[-1].comm_node  # type: ignore
 
     fused_comm_node.update_arg(0, [jit_buffer_node])  # type: ignore
 
@@ -1077,7 +1077,7 @@ def _scatter_results_jit(
 
     # ensure user
 
-    wait_user: fx.Node = cast(Tuple[fx.Node], wait_node.args)[0]
+    wait_user = cast(fx.Node, cast(fx.Node, wait_node).args[0])
     wait_node.users[wait_user] = ""  # type: ignore
 
     scatter_nodes = []

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1137,6 +1137,7 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
     We can thus del the gradient tensors as fused, and by only creating buffers as
     needed, minimize overhead memory pressure."""
     MBFACTOR = float(1 << 20)
+    FP32_BYTES = 4
 
     gm.recompile()
     graph_info = GraphInfo().update_info(gm)
@@ -1167,7 +1168,8 @@ def run_fuse_communication_jit(gm: fx.GraphModule, fusion_length: int) -> None:
     curr_size = 0
 
     for i, fe in enumerate(graph_info.fe_list):
-        curr_size += fe.size
+        # TODO - we assume fp32 atm.
+        curr_size += fe.size * FP32_BYTES
         if curr_size >= bucket_size:
             stop = i + 1
             fe_list = graph_info.fe_list[start:stop]

--- a/spmd/compiler/fusion.py
+++ b/spmd/compiler/fusion.py
@@ -1036,7 +1036,7 @@ def _fuse_with_jit(
 
     assert copy_list[-1].comm_node is not None
 
-    fused_comm_node = cast(fx.Node, copy_list[-1].comm_node)
+    fused_comm_node = copy_list[-1].comm_node
     fused_comm_node.update_arg(0, [jit_buffer_node])
 
     fused_comm_node.users[jit_buffer_node] = ""  # type: ignore
@@ -1076,7 +1076,7 @@ def _scatter_results_jit(
 
     # ensure user
 
-    wait_user = wait_node.args[0]
+    wait_user = cast(Tuple[fx.Node], wait_node.args)[0]
     wait_node.users[wait_user] = ""  # type: ignore
 
     scatter_nodes = []

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -190,7 +190,7 @@ class DistGraphOptimization:
         self,
         bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
         scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
-        fusion_length: int = 10,
+        fusion_length: int = 2,
     ) -> "DistGraphOptimization":
         assert len(
             self._graph.bwd_graph_modules

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -9,7 +9,6 @@ from .distributed_graph import DistributedGraph
 from .fusion import (
     run_fuse_communication_ring,
     run_fuse_communication_cat,
-    run_overlap_communication,
     run_fuse_communication_jit,
 )
 from .log_utils import rank0_info

--- a/spmd/compiler/graph_optimization.py
+++ b/spmd/compiler/graph_optimization.py
@@ -10,6 +10,7 @@ from .fusion import (
     run_fuse_communication_ring,
     run_fuse_communication_cat,
     run_overlap_communication,
+    run_fuse_communication_jit,
 )
 from .log_utils import rank0_info
 from .scheduling_policies import SchedulingPolicy
@@ -23,7 +24,7 @@ _run_before_sets: DefaultDict[str, Set[str]] = defaultdict(set)
 
 class GraphOptimizationType(str, Enum):
     NOOP = "noop"
-    OVERLAP_COMMUNICATION = "overlap_communication"
+    FUSE_COMMUNICATION_JIT = "fuse_communication_jit"
     FUSE_COMMUNICATION_RING = "fuse_communication_ring"
     FUSE_COMMUNICATION_CAT = "fuse_communication_cat"
 
@@ -202,13 +203,20 @@ class DistGraphOptimization:
         return self
 
     @graph_optimization_pass()
-    def overlap_communication(self) -> "DistGraphOptimization":
+    def fuse_communication_jit(
+        self,
+        bucketing_strategy: BucketingStrategy = BucketingStrategy.FIXED,
+        scheduling_policy: SchedulingPolicy = SchedulingPolicy.FCFS,
+        fusion_length: int = 2,
+    ) -> "DistGraphOptimization":
 
         assert len(
             self._graph.bwd_graph_modules
         ), f"no bwd graph ready from {self._graph.bwd_graph_modules}"
 
-        run_overlap_communication(self._graph.bwd_graph_modules[0])
+        run_fuse_communication_jit(
+            self._graph.bwd_graph_modules[0], fusion_length
+        )
         return self
 
     @graph_optimization_pass()

--- a/test/spmd/compiler/test_graph_optimizations.py
+++ b/test/spmd/compiler/test_graph_optimizations.py
@@ -73,9 +73,9 @@ class CommOverlapTest(DTensorTestBase):
         all_spmd = []
         optimizations = [
             [],
-            [GraphOptimization("overlap_communication")],
             [GraphOptimization("fuse_communication_ring")],
             [GraphOptimization("fuse_communication_cat")],
+            [GraphOptimization("fuse_communication_jit")],
         ]
         for optim in optimizations:
             spmd = SPMD(


### PR DESCRIPTION
This PR implements:
1 - JIT fusion - this is fusion where a local buffer is created for each fusion group, rather than using a global buffer.  
2 - a mb based policy for JIT instead of integer fusion (i.e. comms are fused once they exceed the MB size rather than a count of total comms to fuse)
3 - Removes overlap_communication optimization.  This was an interim optimization to disperse the comms but is now integrated into the full policies ala JIT, Ring, CAT. 