### PR TITLE
[checkpoint] Add example to show how to extend FileSystemWriter

### DIFF
--- a/spmd/checkpoint/multi_host_file_system_writer.py
+++ b/spmd/checkpoint/multi_host_file_system_writer.py
@@ -1,0 +1,8 @@
+import os
+from torch.distributed.checkpoint import SavePlan, FileSystemWriter
+
+
+class MultiHostFileSystemWriter(FileSystemWriter):
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        os.makedirs(self.path, exist_ok=True)
+        return plan


### PR DESCRIPTION
This is an example to show how to subclass FileSystemWriter and overriding prepare_local_plan. This would fix the issue of directory not exists when running checkpoint on multiple hosts. 