### PR TITLE
[checkpoint] Fix pg planner

### DIFF
--- a/spmd/checkpoint/pg_planner.py
+++ b/spmd/checkpoint/pg_planner.py
@@ -52,7 +52,9 @@ class ProcessGroupAwareSavePlanner(DefaultSavePlanner):
     ProcessGroupAwareSavePlanner extends DefaultSavePlanner and re-write the state_dict.
     """
 
-    def set_up_planner(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
+    def set_up_planner(
+        self, state_dict: Dict[str, Any], is_coordinator: bool
+    ) -> None:
         """
         Rename all keys of sharded tensors from sub-process groups by prefixing it
         with a PG specific string.

--- a/spmd/checkpoint/pg_planner.py
+++ b/spmd/checkpoint/pg_planner.py
@@ -52,13 +52,13 @@ class ProcessGroupAwareSavePlanner(DefaultSavePlanner):
     ProcessGroupAwareSavePlanner extends DefaultSavePlanner and re-write the state_dict.
     """
 
-    def init(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
+    def set_up_planner(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
         """
         Rename all keys of sharded tensors from sub-process groups by prefixing it
         with a PG specific string.
         """
         self.state_dict = create_state_dict_copy(state_dict)  # pyre-ignore[16]
-        super().init(self.state_dict, is_coordinator)
+        super().set_up_planner(self.state_dict, is_coordinator)
 
 
 class ProcessGroupAwareLoadPlanner(DefaultLoadPlanner):
@@ -66,7 +66,7 @@ class ProcessGroupAwareLoadPlanner(DefaultLoadPlanner):
     ProcessGroupAwareSaveLoader extends DefaultLoadPlanner and re-write the state_dict.
     """
 
-    def init(
+    def set_up_planner(
         self,
         state_dict: STATE_DICT_TYPE,
         metadata: Metadata,
@@ -78,7 +78,7 @@ class ProcessGroupAwareLoadPlanner(DefaultLoadPlanner):
         """
         self.pg_original_state_dict = state_dict  # pyre-ignore[16]
         self.state_dict = create_state_dict_copy(state_dict)  # pyre-ignore[16]
-        super().init(self.state_dict, metadata, is_coordinator)
+        super().set_up_planner(self.state_dict, metadata, is_coordinator)
 
     def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
         """

--- a/test/spmd/checkpoint/test_pg_planner.py
+++ b/test/spmd/checkpoint/test_pg_planner.py
@@ -110,7 +110,11 @@ class TestProcessGroupAwarePlanner(DTensorTestBase):
             cp.save_state_dict(
                 state_dict=state_dict,
                 storage_writer=cp.FileSystemWriter(path=CHECKPOINT_DIR),
-                planner=ProcessGroupAwareSavePlanner(),
+                planner=ProcessGroupAwareSavePlanner(
+                    flatten_sharded_tensors=False,
+                    flatten_state_dict=False,
+                    dedup_replicated_tensors=False,
+                ),
             )
 
         model = MyModule(
@@ -145,7 +149,10 @@ class TestProcessGroupAwarePlanner(DTensorTestBase):
             cp.load_state_dict(
                 state_dict=state_dict,
                 storage_reader=cp.FileSystemReader(path=CHECKPOINT_DIR),
-                planner=ProcessGroupAwareLoadPlanner(),
+                planner=ProcessGroupAwareLoadPlanner(
+                    flatten_sharded_tensors=False,
+                    flatten_state_dict=False,
+                ),
             )
 
             model.load_state_dict(state_dict)


### PR DESCRIPTION
Fix broken CI in pg_planner:
```
spmd/checkpoint/pg_planner.py:61:9: error: "init" undefined in superclass  [misc]
spmd/checkpoint/pg_planner.py:81:9: error: "init" undefined in superclass  [misc]
```

This is changed due to https://github.com/pytorch/pytorch/pull/92829. 



