### PR TITLE
Fix issue that PiPPy does not generate backward pass when there are multiple output values

### DIFF
--- a/examples/resnet/pippy_resnet.py
+++ b/examples/resnet/pippy_resnet.py
@@ -61,7 +61,10 @@ def run_master(_, args):
 
         def forward(self, input, target):
             output = self.module(input)
-            return output, self.loss_fn(output, target)
+            loss = self.loss_fn(output, target)
+            # Here we use a dict with the "loss" keyword so that PiPPy can automatically find the loss field when
+            # generating the backward pass
+            return {"output": output, "loss": loss}
 
     model = ResNet50()
 
@@ -73,7 +76,7 @@ def run_master(_, args):
 
     wrapper = OutputLossWrapper(model, cross_entropy)
 
-    pipe = Pipe.from_tracing(wrapper, MULTI_USE_PARAM_CONFIG, output_loss_value_spec=(False, True))
+    pipe = Pipe.from_tracing(wrapper, MULTI_USE_PARAM_CONFIG)
     pipe.to(args.device)
 
     args_chunk_spec = (TensorChunkSpec(0), TensorChunkSpec(0))

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -103,7 +103,9 @@ def _find_loss_output(
     assert len(output_nodes) == 1
     output_node = output_nodes[0]
 
-    if isinstance(mod, LossWrapper):
+    if isinstance(mod, TrivialLossWrapper):
+        # TrivialLossWrapper is pre-defined by PiPPy.
+        # It has loss as the only output so we can safely assume the first output arg is the loss.
         assert len(output_node.args) == 1
         loss_node = output_node.args[0]
     else:


### PR DESCRIPTION
Issue was reported by user when trying the ResNet example:
[Pippy I can’t see backward pass](https://discuss.pytorch.org/t/pippy-i-cant-see-backward-pass/170630)

### Explanation of the Issue:
When the output is in tuple form and there other values than loss in the tuple, e.g. `return output, loss`, PiPPy could not figure out which field is the loss, and hence did not generate the backward pass.

### Fix to the ResNet example:
The return needs to be in a form of dict, e.g. `return {"output": output, "loss": loss}`, so that PiPPy can automatically locate the loss field by looking at the keyword.

### Fix to PiPPy's IR:
We cannot assume that there is only one output value (loss) when the model is of the general `LossWrapper` class. Such assumption is only valid for the `TrivialLossWrapper` class.