### PR TITLE
Make output chunk spec optional

### DIFF
--- a/example.py
+++ b/example.py
@@ -124,10 +124,10 @@ if local_rank == 0:
     driver = PipelineDriverFillDrain(
         pipe,
         64,
+        world_size=world_size,
         args_chunk_spec=args_chunk_spec,
         kwargs_chunk_spec=kwargs_chunk_spec,
         output_chunk_spec=output_chunk_spec,
-        world_size=world_size,
     )
 
     x = torch.randn(512, 512)

--- a/example_train.py
+++ b/example_train.py
@@ -137,10 +137,10 @@ if local_rank == 0:
     driver = PipelineDriverFillDrain(
         pipe,
         64,
+        world_size=world_size,
         args_chunk_spec=args_chunk_spec,
         kwargs_chunk_spec=kwargs_chunk_spec,
         output_chunk_spec=output_chunk_spec,
-        world_size=world_size,
     )
 
     # Instantiate remote Adam optimizers. `instantiate_optimizer` takes the

--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -70,7 +70,6 @@ def run_master(_, args):
     bs = 503
 
     # Chunking parameters
-    output_chunk_spec = (TensorChunkSpec(0),)
     chunks = 1
 
     # Ask Dynamo to let PiPPy annotation stay in graph
@@ -94,7 +93,6 @@ def run_master(_, args):
         pipe_driver: PipelineDriverBase = schedules[args.schedule](
             pipe,
             chunks,
-            output_chunk_spec,
             args.world_size,
             checkpoint=bool(args.checkpoint),
             use_c10d=True,

--- a/examples/TorchDynamo/pippy_dynamo.py
+++ b/examples/TorchDynamo/pippy_dynamo.py
@@ -21,7 +21,6 @@ from pippy.PipelineDriver import (
     PipelineDriver1F1B,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -15,7 +15,6 @@ from pippy.PipelineDriver import (
     PipelineDriver1F1B,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.microbatch import TensorChunkSpec
 
 schedules = {
     "FillDrain": PipelineDriverFillDrain,

--- a/examples/gspmd/pippy_gspmd.py
+++ b/examples/gspmd/pippy_gspmd.py
@@ -75,13 +75,11 @@ def run_gspmd(pp_ranks, args):
     if args.rank > 0:
         return  # Workers stop here
 
-    output_chunk_spec = {"out": TensorChunkSpec(0)}
     chunks = 5
 
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         chunks,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/examples/hf/bert/pippy_bert.py
+++ b/examples/hf/bert/pippy_bert.py
@@ -97,9 +97,8 @@ def run_master(_, args):
     for i, sm in enumerate(bert_pipe.split_gm.children()):
         print(f"submod_{i} {get_number_of_params(sm) // 10 ** 6}M params")
 
-    output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0)}
     pipe_driver: PipelineDriverBase = schedules[args.schedule](bert_pipe, chunks,
-                                                               output_chunk_spec, len(all_worker_ranks),
+                                                               len(all_worker_ranks),
                                                                all_ranks=all_worker_ranks,
                                                                _debug_mask_minibatches=False,
                                                                _record_mem_dumps=bool(args.record_mem_dumps),

--- a/examples/hf/bert/pippy_bert.py
+++ b/examples/hf/bert/pippy_bert.py
@@ -14,7 +14,6 @@ from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B, Pi
     PipelineDriverBase
 from pippy.events import EventsContext
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import CustomReducer, TensorChunkSpec
 from pippy.visualizer import events_to_json
 
 PROFILING_ENABLED = True

--- a/examples/hf/gpt2/pippy_gpt2.py
+++ b/examples/hf/gpt2/pippy_gpt2.py
@@ -15,7 +15,7 @@ from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B, Pi
     PipelineDriverBase
 from pippy.events import EventsContext
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import CustomReducer, TensorChunkSpec, Replicate
+from pippy.microbatch import sum_reducer, TensorChunkSpec, Replicate
 from pippy.visualizer import events_to_json
 
 PROFILING_ENABLED = True
@@ -129,13 +129,13 @@ def run_gspmd(pp_ranks, args):
         print(f"submod_{i} {get_number_of_params(sm) // 10 ** 6}M params")
 
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'labels': TensorChunkSpec(0), 'position_ids': Replicate}
-    output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0),
+    output_chunk_spec = {'loss': sum_reducer, 'logits': TensorChunkSpec(0),
                          'past_key_values': [[TensorChunkSpec(0) for _ in range(2)] for _ in range(config.n_layer)]}
     pipe_driver: PipelineDriverBase = schedules[args.schedule](gpt2_pipe, chunks,
-                                                               output_chunk_spec, len(all_worker_ranks),
+                                                               len(all_worker_ranks),
                                                                all_ranks=all_worker_ranks,
                                                                kwargs_chunk_spec = kwargs_chunk_spec,
-                                                               _debug_mask_minibatches=False,
+                                                               output_chunk_spec=output_chunk_spec,
                                                                _record_mem_dumps=bool(args.record_mem_dumps),
                                                                checkpoint=bool(args.checkpoint),
                                                               )

--- a/examples/hf/language-modeling/run_clm.py
+++ b/examples/hf/language-modeling/run_clm.py
@@ -30,7 +30,6 @@ from itertools import chain
 from typing import Optional
 
 import datasets
-import torch
 from datasets import load_dataset
 
 import evaluate

--- a/examples/hf/language-modeling/run_clm.py
+++ b/examples/hf/language-modeling/run_clm.py
@@ -53,7 +53,7 @@ from transformers.utils.versions import require_version
 
 from pippy import run_pippy
 from pippy.hf import PiPPyTrainingArguments, PiPPyTrainer, wrap
-from pippy.microbatch import TensorChunkSpec, CustomReducer
+from pippy.microbatch import TensorChunkSpec, sum_reducer
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.22.0.dev0")
@@ -403,7 +403,7 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     # The kwarg keywords are needed for FX tracing's concrete_args setting (in the `wrap` call)
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'labels': TensorChunkSpec(0),
                          'attention_mask': TensorChunkSpec(0)}
-    output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0),
+    output_chunk_spec = {'loss': sum_reducer, 'logits': TensorChunkSpec(0),
                          'past_key_values': [[TensorChunkSpec(0) for _ in range(2)] for _ in
                                              range(model.config.n_layer)]}
     model = wrap(model,

--- a/examples/hf/language-modeling/run_clm.py
+++ b/examples/hf/language-modeling/run_clm.py
@@ -409,8 +409,9 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     model = wrap(model,
                  training_args,
                  pp_ranks,
-                 output_chunk_spec,
-                 kwargs_chunk_spec=kwargs_chunk_spec)
+                 kwargs_chunk_spec=kwargs_chunk_spec,
+                 output_chunk_spec=output_chunk_spec,
+    )
     training_args.label_names = ['labels']  # https://github.com/huggingface/transformers/blob/c8b6ae858d61e5bc10e388d095aa74f7690d1021/src/transformers/trainer.py#L629-L630
     # ================================================ PiPPy change end ================================================
 

--- a/examples/hf/language-modeling/run_mlm.py
+++ b/examples/hf/language-modeling/run_mlm.py
@@ -401,6 +401,8 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     model.resize_token_embeddings(len(tokenizer))
 
     # =============================================== PiPPy change start ===============================================
+    # Setting model to training mode so that PiPPy would automatically look for "loss" and generate backward pass
+    model.train()
     # The kwarg keywords are needed for FX tracing's concrete_args setting (in the `wrap` call)
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0),
                          'labels': TensorChunkSpec(0), 'attention_mask': TensorChunkSpec(0)}

--- a/examples/hf/language-modeling/run_mlm.py
+++ b/examples/hf/language-modeling/run_mlm.py
@@ -51,7 +51,7 @@ from transformers.utils.versions import require_version
 
 from pippy import run_pippy
 from pippy.hf import PiPPyTrainingArguments, PiPPyTrainer, wrap
-from pippy.microbatch import TensorChunkSpec, CustomReducer
+from pippy.microbatch import TensorChunkSpec
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.22.0.dev0")

--- a/examples/hf/language-modeling/run_mlm.py
+++ b/examples/hf/language-modeling/run_mlm.py
@@ -30,7 +30,6 @@ from itertools import chain
 from typing import Optional
 
 import datasets
-import torch
 from datasets import load_dataset
 
 import evaluate

--- a/examples/hf/language-modeling/run_mlm.py
+++ b/examples/hf/language-modeling/run_mlm.py
@@ -405,11 +405,9 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     # The kwarg keywords are needed for FX tracing's concrete_args setting (in the `wrap` call)
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0),
                          'labels': TensorChunkSpec(0), 'attention_mask': TensorChunkSpec(0)}
-    output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0)}
     model = wrap(model,
                  training_args,
                  pp_ranks,
-                 output_chunk_spec,
                  kwargs_chunk_spec=kwargs_chunk_spec)
     training_args.label_names = ['labels']  # https://github.com/huggingface/transformers/blob/c8b6ae858d61e5bc10e388d095aa74f7690d1021/src/transformers/trainer.py#L629-L630
     # ================================================ PiPPy change end ================================================

--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -185,15 +185,6 @@ def transform_into_pipeline(
     # t5_pipe.to(device) TODO: Uncomment this after https://github.com/pytorch/PiPPy/issues/142
     # t5_pipe(**t5_input_dict)
 
-    if args.train:
-        output_chunk_spec = {"loss": CustomReducer(torch.tensor(0.0), lambda a, b: a + b)}
-    else:
-        output_chunk_spec = {}
-    output_chunk_spec.update({
-        "logits": TensorChunkSpec(0),
-        "encoder_last_hidden_state": TensorChunkSpec(0),
-    })
-
     # We can use c10d for inference mode now
     use_c10d = False if args.train else True
     print(f"use_c10d: {use_c10d}")
@@ -201,7 +192,6 @@ def transform_into_pipeline(
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         t5_pipe,
         chunks,
-        output_chunk_spec,
         world_size=len(all_worker_ranks),
         all_ranks=all_worker_ranks,
         _debug_mask_minibatches=False,

--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -225,7 +225,6 @@ def run_master(pp_ranks, args):
     t5.to(
         device
     )  # TODO: Delete this after https://github.com/pytorch/PiPPy/issues/142
-    t5.eval()
     print(t5.config)
     print(f"T5 total number of params = {get_number_of_params(t5) // 10 ** 6}M")
 

--- a/examples/hf/t5/pippy_t5.py
+++ b/examples/hf/t5/pippy_t5.py
@@ -26,7 +26,6 @@ from pippy.PipelineDriver import (
 from pippy import split_on_size_threshold, split_into_equal_size
 from pippy.events import EventsContext
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import CustomReducer, TensorChunkSpec
 from pippy.visualizer import events_to_json
 
 PROFILING_ENABLED = True

--- a/examples/hf/text-classification/run_glue.py
+++ b/examples/hf/text-classification/run_glue.py
@@ -25,7 +25,6 @@ from typing import Optional
 
 import datasets
 import numpy as np
-import torch
 from datasets import load_dataset
 
 import evaluate
@@ -47,7 +46,7 @@ from transformers.utils.versions import require_version
 
 from pippy import run_pippy
 from pippy.hf import PiPPyTrainingArguments, PiPPyTrainer, wrap
-from pippy.microbatch import TensorChunkSpec, CustomReducer
+from pippy.microbatch import TensorChunkSpec
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.22.0.dev0")

--- a/examples/hf/text-classification/run_glue.py
+++ b/examples/hf/text-classification/run_glue.py
@@ -391,11 +391,9 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     model.config.problem_type = "single_label_classification"  # "regression", "single_label_classification", or "multi_label_classification"
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'token_type_ids': TensorChunkSpec(0),
                          'labels': TensorChunkSpec(0), 'attention_mask': TensorChunkSpec(0)}
-    output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b), 'logits': TensorChunkSpec(0)}
     model = wrap(model,
                  training_args,
                  pp_ranks,
-                 output_chunk_spec,
                  kwargs_chunk_spec=kwargs_chunk_spec)
     training_args.label_names = ['labels']  # https://github.com/huggingface/transformers/blob/c8b6ae858d61e5bc10e388d095aa74f7690d1021/src/transformers/trainer.py#L629-L630
     # ================================================ PiPPy change end ================================================

--- a/examples/hf/text-classification/run_glue.py
+++ b/examples/hf/text-classification/run_glue.py
@@ -386,7 +386,8 @@ def run_master(pp_ranks, training_args, model_args, data_args):
     )
 
     # =============================================== PiPPy change start ===============================================
-
+    # Setting model to training mode so that PiPPy would automatically look for "loss" and generate backward pass
+    model.train()
     model.config.problem_type = "single_label_classification"  # "regression", "single_label_classification", or "multi_label_classification"
     kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'token_type_ids': TensorChunkSpec(0),
                          'labels': TensorChunkSpec(0), 'attention_mask': TensorChunkSpec(0)}

--- a/examples/hf/translation/run_translation.py
+++ b/examples/hf/translation/run_translation.py
@@ -402,7 +402,7 @@ def run_master(pp_ranks, training_args, model_args, data_args):
                          'logits': TensorChunkSpec(0),
                          'encoder_last_hidden_state': TensorChunkSpec(0),
                         }
-    if model.config.use_cache:
+    if model.__class__.__name__ == 'T5ForConditionalGeneration' and model.config.use_cache:
         # past_key_values, optional, returned when use_cache=True is passed or when config.use_cache=True.
         output_chunk_spec['past_key_values'] = [
             [TensorChunkSpec(0) for _ in range(model.config.num_decoder_layers)] for _ in range(4)

--- a/examples/inference/HF_inference.py
+++ b/examples/inference/HF_inference.py
@@ -135,16 +135,7 @@ def run_master(pp_ranks, args):
         total_params += params
     print(f"total {total_params // 10 ** 6}M params")
 
-    if 't5' in args.model_name:
-        output_chunk_spec = {"logits": TensorChunkSpec(0),"encoder_last_hidden_state": TensorChunkSpec(0)}
-    elif 'opt' or 'bloom' in args.model_name:
-        output_chunk_spec = {"logits": TensorChunkSpec(0)}
-    elif 'regnet' in args.model_name:
-        output_chunk_spec = {"last_hidden_state": TensorChunkSpec(0), 'hidden_states':TensorChunkSpec(0)}
-    
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](model_pipe, chunks,
-                                                               output_chunk_spec,
                                                                world_size=len(all_worker_ranks),
                                                                all_ranks=all_worker_ranks,
                                                                 )

--- a/examples/inference/HF_inference.py
+++ b/examples/inference/HF_inference.py
@@ -12,7 +12,6 @@ from pippy.IR import MultiUseParameterConfig, Pipe
 from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B, PipelineDriverInterleaved1F1B, \
     PipelineDriverBase
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import TensorChunkSpec
 from pippy import split_on_size_threshold, split_into_equal_size
 from transformers import  AutoModelForSeq2SeqLM
 from transformers import OPTModel, BloomModel

--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -101,7 +101,9 @@ The barrier would make sure all the rank have loaded their shards and finally we
         return 
  ```
 
-* Define the input/ouput to the model, "TensorChunkSpec(0)" below shows the batch dimension in the input is zero. Pipelining relies on _micro-batching_--that is--the process of dividing the program's input data into smaller chunks and feeding those chunks through the pipeline sequentially. Doing this requires that the data and operations be _separable_, i.e.there should be at least one dimension along which data can be split such that the program does not have interactions across this dimension.
+* (Optional) Define the input/ouput to the model. "TensorChunkSpec(0)" below indicates that the batch dimension in the input is zero. Pipelining relies on _micro-batching_--that is--the process of dividing the program's input data into smaller chunks and feeding those chunks through the pipeline sequentially. Doing this requires that the data and operations be _separable_, i.e.there should be at least one dimension along which data can be split such that the program does not have interactions across this dimension.
+
+By default, PiPPy uses dimension 0 as the input chunking or output merging dimension. Therefore, the settings below are optional.
 
 ```
 kwargs_chunk_spec = {'input_ids': TensorChunkSpec(0), 'decoder_input_ids': TensorChunkSpec(0)}
@@ -120,7 +122,6 @@ schedules = {
 
 ```
 pipe_driver: PipelineDriverBase = schedules[args.schedule](t5_pipe, chunks, args_chunk_spec, kwargs_chunk_spec,
-                                                            output_chunk_spec,
                                                             world_size=len(all_worker_ranks),
                                                             all_ranks=all_worker_ranks,
                                                             checkpoint=bool(args.checkpoint), #optional in case pretrained weights not required

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -948,6 +948,7 @@ class Pipe(torch.nn.Module):
         num_stages = Pipe._number_and_count_forward_stages(split)
 
         has_loss_and_backward = False
+        generated_loss_spec = output_loss_value_spec
 
         if mod.training:
             loss_node, output_node, generated_loss_spec = _find_loss_output(

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -84,13 +84,6 @@ def _find_loss_from_output_and_spec(output_val, spec_val):
             f"Did not find loss value in specification {spec_val}"
         )
 
-    if spec_val is None:
-        # Use default spec, i.e. search for "loss" in output values
-        if isinstance(output_val, dict) and "loss" in output_val.keys():
-            return output_val["loss"]
-        else:
-            return None
-
     raise RuntimeError(
         f"Unsupported type {type(spec_val)} in loss specification"
     )
@@ -102,18 +95,30 @@ def _find_loss_output(
     output_nodes = [n for n in g.nodes if n.op == "output"]
     assert len(output_nodes) == 1
     output_node = output_nodes[0]
+    output_val = output_node.args[0]
 
     if isinstance(mod, TrivialLossWrapper):
         # TrivialLossWrapper is pre-defined by PiPPy.
         # It has loss as the only output so we can safely assume the first output arg is the loss.
         assert len(output_node.args) == 1
-        loss_node = output_node.args[0]
+        loss_node = output_val
+        generated_spec = TrivialLossWrapper.loss_spec
+    elif output_loss_value_spec is None:
+        # Use default spec, i.e. search for "loss" in output values
+        if isinstance(output_val, dict) and "loss" in output_val.keys():
+            loss_node = output_val["loss"]
+            generated_spec = dict.fromkeys(output_val, False)
+            generated_spec["loss"] = True
+        else:
+            loss_node = None
+            generated_spec = None
     else:
         loss_node = _find_loss_from_output_and_spec(
-            output_node.args[0], output_loss_value_spec
+            output_val, output_loss_value_spec
         )
+        generated_spec = output_loss_value_spec
 
-    return loss_node, output_node
+    return loss_node, output_node, generated_spec
 
 
 def _insert_stage_symbolic_backward(
@@ -308,6 +313,8 @@ class TrivialLossWrapper(LossWrapper):
         model_out = self.module(x)
         return self.loss_fn(model_out, targets)
 
+    loss_spec = True
+
 
 # Pipe model representation
 #
@@ -489,12 +496,14 @@ class Pipe(torch.nn.Module):
         qualname_mapping: Dict[str, str],
         num_stages: int,
         has_loss_and_backward: bool,
+        loss_spec,
     ):
         super().__init__()
         self.split_gm: pippy.fx.GraphModule = split_gm
         self.executor: DetachExecutor = DetachExecutor(self.split_gm)
         self.num_stages: int = num_stages
         self.has_loss_and_backwards = has_loss_and_backward
+        self.loss_spec = loss_spec
         self.last_grads = None
 
         for node in split_gm.graph.nodes:
@@ -942,7 +951,7 @@ class Pipe(torch.nn.Module):
         has_loss_and_backward = False
 
         if mod.training:
-            loss_node, output_node = _find_loss_output(
+            loss_node, output_node, generated_loss_spec = _find_loss_output(
                 mod, split.graph, output_loss_value_spec
             )
             if loss_node is not None:
@@ -958,7 +967,13 @@ class Pipe(torch.nn.Module):
                     "`output_loss_value_spec`."
                 )
 
-        return Pipe(split, qualname_map, num_stages, has_loss_and_backward)
+        return Pipe(
+            split,
+            qualname_map,
+            num_stages,
+            has_loss_and_backward,
+            generated_loss_spec,
+        )
 
     @staticmethod
     def from_tracing(

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -961,12 +961,19 @@ class Pipe(torch.nn.Module):
                 )
                 split.recompile()
                 has_loss_and_backward = True
+                logging.info(
+                    "Pipeline is in training mode, backward pass generated"
+                )
             else:
                 logging.warning(
                     "Did not find any loss value from model output, your pipeline will be in inference mode. "
                     "If you want your pipeline to be in training mode, please specify a loss value via "
                     "`output_loss_value_spec`."
                 )
+        else:
+            logging.info(
+                "Pipeline is in evaluation mode, backward pass not generated"
+            )
 
         return Pipe(
             split,

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -107,8 +107,7 @@ def _find_loss_output(
         # Use default spec, i.e. search for "loss" in output values
         if isinstance(output_val, dict) and "loss" in output_val.keys():
             loss_node = output_val["loss"]
-            generated_spec = dict.fromkeys(output_val, False)
-            generated_spec["loss"] = True
+            generated_spec = {k: k == "loss" for k in output_val}
         else:
             loss_node = None
             generated_spec = None

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -3,7 +3,7 @@ import copy
 import logging
 import operator
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.fx as torch_fx
@@ -96,6 +96,7 @@ def _find_loss_output(
     assert len(output_nodes) == 1
     output_node = output_nodes[0]
     output_val = output_node.args[0]
+    generated_spec: Any = None
 
     if isinstance(mod, TrivialLossWrapper):
         # TrivialLossWrapper is pre-defined by PiPPy.

--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -330,7 +330,8 @@ def wrap(
     MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
     if isinstance(output_chunk_spec, dict):
         output_loss_value_spec = {
-            k: isinstance(v, CustomReducer) for k, v in output_chunk_spec.items()
+            k: isinstance(v, CustomReducer)
+            for k, v in output_chunk_spec.items()
         }
     model_config = model.config
 

--- a/pippy/hf/utils.py
+++ b/pippy/hf/utils.py
@@ -5,7 +5,7 @@ import logging
 import os
 import types
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.distributed
@@ -328,6 +328,7 @@ def wrap(
         if p.name not in input_names
     }
     MULTI_USE_PARAM_CONFIG = MultiUseParameterConfig.TRANSMIT
+    output_loss_value_spec: Any = None
     if isinstance(output_chunk_spec, dict):
         output_loss_value_spec = {
             k: isinstance(v, CustomReducer)

--- a/pippy/microbatch.py
+++ b/pippy/microbatch.py
@@ -1,4 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
+import logging
+from typing import Any
 from pippy.IR import TrivialLossWrapper
 import torch
 
@@ -323,10 +325,11 @@ def merge_chunks(chunks, chunk_spec, _debug_mask_minibatches: bool = False):
 
 
 def gen_output_chunk_spec(loss_spec, loss_reducer):
+    output_chunk_spec: Any = None
     if loss_spec is None:
-        return None
+        pass
     elif loss_spec == TrivialLossWrapper.loss_spec:
-        return loss_reducer
+        output_chunk_spec = loss_reducer
     elif isinstance(loss_spec, dict):
         output_chunk_spec = {
             k: loss_reducer
@@ -334,6 +337,11 @@ def gen_output_chunk_spec(loss_spec, loss_reducer):
             else TensorChunkSpec(DEFAULT_CHUNK_DIM)
             for k in loss_spec
         }
-        return output_chunk_spec
     else:
         raise ValueError(f"Cannot generate output chunk spec for {loss_spec}")
+
+    logging.info(
+        f"Generated output_chunk_spec for loss_spec {loss_spec}: "
+        f"{output_chunk_spec}"
+    )
+    return output_chunk_spec

--- a/pippy/microbatch.py
+++ b/pippy/microbatch.py
@@ -235,7 +235,13 @@ def merge_chunks(chunks, chunk_spec, _debug_mask_minibatches: bool = False):
     #       value = ([A, [B, C]], D)
 
     # Preliminary: flatten the chunk spec
-    spec_flattened, flatten_spec = tree_flatten(chunk_spec)
+    if chunk_spec is not None:
+        spec_flattened, flatten_spec = tree_flatten(chunk_spec)
+    else:
+        # If chunk_spec is not provided, we will merge chunks along the default dimension (0), for all output fields
+        # We obtain the output structure by flattening chunk 0 and generate the chunk_spec
+        chunk0_flat, flatten_spec = tree_flatten(chunks[0])
+        spec_flattened = [TensorChunkSpec(DEFAULT_CHUNK_DIM)] * len(chunk0_flat)
 
     # Stage 1: flatten chunks
     # chunks_flattened : [num chunks, num args]

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -16,7 +16,6 @@ from pippy.PipelineDriver import (
     PipelineDriver1F1B,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_autosplit.py
+++ b/test/local_test_autosplit.py
@@ -81,14 +81,12 @@ def inspect_split_module(
 
 # Common function to run pipeline with input and check equivalence
 def run_pipe_driver(ec_pipe, args):
-    output_chunk_spec = {"out": TensorChunkSpec(0)}
 
     nstages = len(list(ec_pipe.split_gm.children()))
 
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         nstages,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_ddp.py
+++ b/test/local_test_ddp.py
@@ -21,7 +21,6 @@ from pippy.PipelineDriver import (
     PipelineDriverBase,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.microbatch import CustomReducer
 
 # TODOs for implementing forward/backward/loss with schedules:
 # * ability to switch between full-batch loss vs. per-microbatch loss. shen mentioned

--- a/test/local_test_ddp.py
+++ b/test/local_test_ddp.py
@@ -115,12 +115,9 @@ def run_master(pp_ranks, args):
     if args.rank == 0:
         print(ec_pipe.split_gm)
 
-    output_chunk_spec = CustomReducer(torch.tensor(0.0), lambda a, b: a + b)
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         CHUNKS,
-        output_chunk_spec,
         args.pp_group_size,
         all_ranks=pp_ranks,
         _debug_mask_minibatches=DEBUG_MASK_MINIBATCHES,

--- a/test/local_test_forward.py
+++ b/test/local_test_forward.py
@@ -74,12 +74,9 @@ def run_master(_, args):
     ec_pipe = Pipe.from_tracing(ec, MULTI_USE_PARAM_CONFIG)
     print(ec_pipe.split_gm)
 
-    output_chunk_spec = {"out": TensorChunkSpec(0)}
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         5,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_forward.py
+++ b/test/local_test_forward.py
@@ -15,7 +15,6 @@ from pippy.PipelineDriver import (
     PipelineDriver1F1B,
     PipelineDriverInterleaved1F1B,
 )
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_forward_auto_parallel.py
+++ b/test/local_test_forward_auto_parallel.py
@@ -16,7 +16,6 @@ from pippy.PipelineDriver import (
     PipelineDriverInterleaved1F1B,
 )
 from pippy.auto_parallelization import AutoParallelConfig, dp_auto_parallel
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_forward_auto_parallel.py
+++ b/test/local_test_forward_auto_parallel.py
@@ -79,12 +79,9 @@ def run_master(_, args):
     )
     print(ec_pipe.split_gm)
 
-    output_chunk_spec = {"out": TensorChunkSpec(0)}
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         5,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_forward_backward.py
+++ b/test/local_test_forward_backward.py
@@ -148,12 +148,9 @@ def run_master(_, args):
     ec_pipe = Pipe.from_tracing(wrapper, MULTI_USE_PARAM_CONFIG)
     print(ec_pipe.split_gm)
 
-    output_chunk_spec = CustomReducer(torch.tensor(0.0), lambda a, b: a + b)
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         CHUNKS,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=DEBUG_MASK_MINIBATCHES,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_forward_backward.py
+++ b/test/local_test_forward_backward.py
@@ -22,7 +22,6 @@ from pippy.PipelineDriver import (
     PipelineDriverInterleaved1F1B,
 )
 from pippy.microbatch import (
-    CustomReducer,
     split_args_kwargs_into_chunks,
 )
 

--- a/test/local_test_forward_hf_bert.py
+++ b/test/local_test_forward_hf_bert.py
@@ -21,7 +21,6 @@ from pippy.PipelineDriver import (
     PipelineDriverBase,
 )
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_forward_hf_bert.py
+++ b/test/local_test_forward_hf_bert.py
@@ -83,15 +83,9 @@ def run_master(_, args):
         list(bert_pipe.split_gm.children())
     )
 
-    output_chunk_spec = {
-        "last_hidden_state": TensorChunkSpec(0),
-        "pooler_output": TensorChunkSpec(0),
-    }
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         bert_pipe,
         5,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_forward_hf_gpt2.py
+++ b/test/local_test_forward_hf_gpt2.py
@@ -21,7 +21,6 @@ from pippy.PipelineDriver import (
     PipelineDriverBase,
 )
 from pippy.hf import PiPPyHFTracer
-from pippy.microbatch import TensorChunkSpec
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_forward_hf_gpt2.py
+++ b/test/local_test_forward_hf_gpt2.py
@@ -78,12 +78,9 @@ def run_master(_, args):
 
     assert gpt2.config.n_layer + 2 == len(list(gpt2_pipe.split_gm.children()))
 
-    output_chunk_spec = {"last_hidden_state": TensorChunkSpec(0)}
-
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         gpt2_pipe,
         5,
-        output_chunk_spec,
         args.world_size,
         _debug_mask_minibatches=True,
         _record_mem_dumps=bool(args.record_mem_dumps),

--- a/test/local_test_null_coalesce_accumulate.py
+++ b/test/local_test_null_coalesce_accumulate.py
@@ -18,7 +18,6 @@ from pippy.PipelineDriver import (
     PipelineDriverFillDrain,
     PipelineDriver1F1B,
 )
-from pippy.microbatch import CustomReducer
 
 PROFILING_ENABLED = True
 CHECK_NUMERIC_EQUIVALENCE = True

--- a/test/local_test_null_coalesce_accumulate.py
+++ b/test/local_test_null_coalesce_accumulate.py
@@ -66,11 +66,9 @@ def run_master(_, args):
     target = torch.randn(bs, hid_dim)
     accum_pipe(input, target)
 
-    output_chunk_spec = CustomReducer(torch.tensor(0.0), lambda a, b: a + b)
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         accum_pipe,
         chunks,
-        output_chunk_spec,
         args.world_size - 1,
         all_ranks=all_ranks,
         _debug_mask_minibatches=True,

--- a/test/local_test_visualizer.py
+++ b/test/local_test_visualizer.py
@@ -28,7 +28,6 @@ from pippy.PipelineDriver import (
     PipelineDriverInterleaved1F1B,
 )
 from pippy.events import Event
-from pippy.microbatch import CustomReducer
 from pippy.visualizer import events_to_json
 
 PROFILING_ENABLED = True

--- a/test/local_test_visualizer.py
+++ b/test/local_test_visualizer.py
@@ -178,13 +178,10 @@ def run_master(_, args):
     wrapper = TrivialLossWrapper(ec, mse_loss)
     ec_pipe = Pipe.from_tracing(wrapper, MULTI_USE_PARAM_CONFIG)
 
-    output_chunk_spec = CustomReducer(torch.tensor(0.0), lambda a, b: a + b)
-
     all_ranks = list(range(1, args.world_size))  # exclude master rank = 0
     pipe_driver: PipelineDriverBase = schedules[args.schedule](
         ec_pipe,
         chunks,
-        output_chunk_spec,
         args.world_size - 1,
         all_ranks=all_ranks,
         _debug_mask_minibatches=True,


### PR DESCRIPTION
`output_chunk_spec` was used to specify how micro-batch outputs should be merged or reduced (if the output field is a loss).

### Previous
Previously, user would need to specify an `output_chunk_spec` to `PipelineDriver`.
For example:
```
output_chunk_spec = {'loss': CustomReducer(torch.tensor(0.0), lambda a, b: a + b),
                     'logits': TensorChunkSpec(0),
                     'encoder_last_hidden_state': TensorChunkSpec(0)}
```

### Now
We automate this process by:
1. Adding an optional `loss_reducer` argument to `PipelineDriver`, which has a default value of `sum_reducer`, i.e.
```
sum_reducer = CustomReducer(torch.tensor(0.0), lambda a, b: a + b)
```
2. If an output field is specified/identified as loss in the earlier `Pipe.from_tracing` call, we would use the provided `loss_reducer` for this field. If `loss_reducer` is not specified, we would use the default `sum_reducer`.
3. For a non-loss output field, we would use `TensorChunkSpec(0)` by default, i.e. merging along the 0 dimension.