### PR TITLE
Generate backward pass when loss is specified

### DIFF
--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -951,7 +951,7 @@ class Pipe(torch.nn.Module):
         has_loss_and_backward = False
         generated_loss_spec = output_loss_value_spec
 
-        if mod.training:
+        if mod.training or output_loss_value_spec is not None:
             loss_node, output_node, generated_loss_spec = _find_loss_output(
                 mod, split.graph, output_loss_value_spec
             )


### PR DESCRIPTION
Three conditions to generate backward:
- model passed to `from_tracing` is in training mode (default for PyTorch modules), and keyword "loss" is found in output;
- `output_loss_value_spec` specifies a loss field with `True`; or
- `output_chunk_spec` specifies a `CustomReducer` (which reduces losses of multiple micro-batches into a single value).