### PR TITLE
Introduce pippy.compile

### DIFF
--- a/.github/workflows/pippy_gpu_tests.sh
+++ b/.github/workflows/pippy_gpu_tests.sh
@@ -34,6 +34,7 @@ set -ex
 # Run all integration tests
 python3 test/local_test_forward.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 test/local_test_forward_backward.py --replicate ${REPLICATE} -s ${SCHEDULE}
+python3 test/local_test_compile.py -s ${SCHEDULE}
 python3 examples/hf/gpt2/pippy_gpt2.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 examples/gspmd/pippy_gspmd.py --replicate ${REPLICATE} -s ${SCHEDULE}
 

--- a/.github/workflows/pippy_tests.yaml
+++ b/.github/workflows/pippy_tests.yaml
@@ -115,6 +115,8 @@ jobs:
         run: python test/local_test_visualizer.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }}
       - name: Run auto-split test
         run: python test/local_test_autosplit.py --replicate ${{ matrix.replicate }} -s ${{ matrix.schedule }}
+      - name: Run compile test
+        run: python test/local_test_compile.py -s ${{ matrix.schedule }} --checkpoint ${{ matrix.checkpoint }}
 
   hf_examples_without_trainer:
     runs-on: linux.12xlarge

--- a/pippy/__init__.py
+++ b/pippy/__init__.py
@@ -11,6 +11,7 @@ from pippy.IR import (
 from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B
 from pippy.ModelSplit import split_on_size_threshold, split_into_equal_size
 from pippy.utils import run_pippy
+from pippy.compile import compile
 
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "PipelineDriver1F1B",
     "split_into_equal_size",
     "split_on_size_threshold",
+    "compile",
 ]

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import logging
+from typing import Any, Callable, List, Optional
+from pippy.PipelineDriver import PipelineDriver1F1B, PipelineDriverFillDrain, PipelineDriverInterleaved1F1B
+import pippy.fx as fx
+from pippy.IR import MultiUseParameterConfig, Pipe
+from pippy.microbatch import LossReducer, sum_reducer
+
+import torch
+
+
+PIPELINE_SCHEDULE_DRIVERS = {
+    "FillDrain": PipelineDriverFillDrain,
+    "1F1B": PipelineDriver1F1B,
+    "Interleaved1F1B": PipelineDriverInterleaved1F1B,
+}
+
+def compile(
+    mod: torch.nn.Module,
+    num_ranks: int,
+    num_chunks: int,
+    schedule: Optional[str] = "FillDrain",
+    split_policy: Optional[
+        Callable[[fx.GraphModule], fx.GraphModule]
+    ] = None,
+    rank: int = None,
+    ranks: List[int] = None,
+    tracer=None,
+    loss_reducer: LossReducer = sum_reducer,
+    args_chunk_spec=None,
+    kwargs_chunk_spec=None,
+    output_chunk_spec=None,
+    checkpoint=False,
+    _debug_mask_minibatches: bool = False,
+    **kwargs,
+):
+    # If a param will be used in multiple pipeline stages, we default the strategy to REPLICATE'ing the param across
+    # stages instead of TRANSMIT'ting it
+    multi_use_param_spec = MultiUseParameterConfig.REPLICATE
+
+    # Figure out which output is loss from output_chunk_spec
+    output_loss_value_spec: Any = None
+    if isinstance(output_chunk_spec, dict):
+        output_loss_value_spec = {
+            k: isinstance(v, LossReducer) for k, v in output_chunk_spec.items()
+        }
+
+    logging.info("[PiPPy] Splitting model ...")
+    pipe_model = Pipe.from_tracing(
+        mod,
+        multi_use_param_spec=multi_use_param_spec,
+        tracer=tracer,
+        output_loss_value_spec=output_loss_value_spec,
+        split_policy=split_policy,
+        **kwargs,
+    )
+    logging.info(pipe_model.split_gm)
+
+    logging.info("[PiPPy] Creating pipeline driver ...")
+    if schedule not in PIPELINE_SCHEDULE_DRIVERS:
+        raise ValueError(
+            f"Unknown pipeline schedule: {schedule}. "
+            f"Please select from {PIPELINE_SCHEDULE_DRIVERS.keys()}"
+        )
+    pipeline_driver = PIPELINE_SCHEDULE_DRIVERS[schedule](
+        pipe_model,
+        num_chunks,
+        num_ranks,
+        all_ranks=ranks,
+        args_chunk_spec=args_chunk_spec,
+        kwargs_chunk_spec=kwargs_chunk_spec,
+        output_chunk_spec=output_chunk_spec,
+        checkpoint=checkpoint,
+        loss_reducer=loss_reducer,
+        _debug_mask_minibatches=_debug_mask_minibatches,
+    )
+
+    return pipeline_driver

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -1,7 +1,11 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 from typing import Any, Callable, List, Optional
-from pippy.PipelineDriver import PipelineDriver1F1B, PipelineDriverFillDrain, PipelineDriverInterleaved1F1B
+from pippy.PipelineDriver import (
+    PipelineDriver1F1B,
+    PipelineDriverFillDrain,
+    PipelineDriverInterleaved1F1B,
+)
 import pippy.fx as fx
 from pippy.IR import MultiUseParameterConfig, Pipe
 from pippy.microbatch import LossReducer, sum_reducer
@@ -15,14 +19,13 @@ PIPELINE_SCHEDULE_DRIVERS = {
     "Interleaved1F1B": PipelineDriverInterleaved1F1B,
 }
 
+
 def compile(
     mod: torch.nn.Module,
     num_ranks: int,
     num_chunks: int,
     schedule: Optional[str] = "FillDrain",
-    split_policy: Optional[
-        Callable[[fx.GraphModule], fx.GraphModule]
-    ] = None,
+    split_policy: Optional[Callable[[fx.GraphModule], fx.GraphModule]] = None,
     rank: int = None,
     ranks: List[int] = None,
     tracer=None,

--- a/test/local_test_compile.py
+++ b/test/local_test_compile.py
@@ -1,0 +1,110 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates
+import argparse
+import os
+import unittest
+import pippy
+from pippy import run_pippy
+from pippy.IR import pipe_split
+
+import torch
+
+d_hid = 512
+bs = 256
+
+class ExampleCode(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mm_param = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.mm_param2 = torch.nn.Parameter(torch.randn(d_hid, d_hid))
+        self.lin = torch.nn.Linear(d_hid, d_hid)
+
+    def forward(self, x):
+        x = torch.mm(x, self.mm_param)
+        skip_connection = x
+        x = torch.relu(x)
+        pipe_split()
+        x = torch.mm(x, self.mm_param)
+        x = self.lin(x)
+        pipe_split()
+        x = torch.relu(x)
+        x = x + skip_connection
+        x = torch.mm(x, self.mm_param2)
+        pipe_split()
+        x = self.lin(x)
+        x = torch.relu(x)
+        return {"out": x}
+
+
+def run_master(_, args):
+    ec = ExampleCode()
+    ec.to(args.device)
+    ec_input = torch.randn(bs, d_hid, device=args.device)
+
+    # Create pipeline model
+    pipe_ec = pippy.compile(
+        ec,
+        num_ranks=args.world_size,
+        num_chunks=4,
+        schedule=args.schedule,
+        checkpoint=bool(args.checkpoint),
+        _debug_mask_minibatches=True, # for numerical equivalence test only
+    )
+
+    # Warm up and correctness runs
+    out = pipe_ec(ec_input)
+    ref_out = ec(ec_input)
+
+    # run with different chunk size to exercise microbatch and scheduling components
+    torch.testing.assert_close(out["out"], ref_out["out"])
+    print(
+        f'equivalence test passed {torch.sum(out["out"])} ref {torch.sum(ref_out["out"])}'
+    )
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size", type=int, default=int(os.getenv("WORLD_SIZE", 4))
+    )
+    parser.add_argument("--rank", type=int, default=int(os.getenv("RANK", -1)))
+    parser.add_argument(
+        "--master_addr", type=str, default=os.getenv("MASTER_ADDR", "localhost")
+    )
+    parser.add_argument(
+        "--master_port", type=str, default=os.getenv("MASTER_PORT", "29500")
+    )
+    parser.add_argument(
+        "-s",
+        "--schedule",
+        type=str,
+        default="FillDrain",
+    )
+    parser.add_argument(
+        "--cuda", type=int, default=int(torch.cuda.is_available())
+    )
+    parser.add_argument("--checkpoint", type=int, default=0, choices=[0, 1])
+    args = parser.parse_args(args)
+
+    # Interleaved 1F1B uses less ranks than number of stages
+    if args.schedule == "Interleaved1F1B":
+        args.world_size = 2
+
+    run_pippy(run_master, args)
+
+
+if __name__ == "__main__":
+    main()
+
+
+class LocalTestCompileTest(unittest.TestCase):
+    def test_compile(self):
+        import random
+
+        port = random.randint(29500, 30000)
+        args = [
+            "--cuda",
+            os.getenv("USE_CUDA", "0"),
+            "--master_port",
+            str(port),
+        ]
+        main(args)

--- a/test/local_test_compile.py
+++ b/test/local_test_compile.py
@@ -11,6 +11,7 @@ import torch
 d_hid = 512
 bs = 256
 
+
 class ExampleCode(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -47,7 +48,7 @@ def run_master(_, args):
         num_chunks=4,
         schedule=args.schedule,
         checkpoint=bool(args.checkpoint),
-        _debug_mask_minibatches=True, # for numerical equivalence test only
+        _debug_mask_minibatches=True,  # for numerical equivalence test only
     )
 
     # Warm up and correctness runs


### PR DESCRIPTION
Previously, PiPPy's use flow is:
```
pipe = Pipe.from_tracing(model, ...)
pipe_driver = PipelineDriver(pipe, ...)
```
Although both `pipe` and `pipe_driver` are `nn.module`, end users mostly just use the `pipe_driver` because this is the distributed version, while `pipe` is just a local version with split stage views.

Therefore, it makes sense to provide a single API to combine the above two functions into a one-stop experience.

The new `pippy.compile` API would hence directly create a distributed `PipelineDriver` out of user's original model.
```
pipe_mod = pippy.compile(
    model,
    num_ranks,
    num_chunks,
    ...
)
```