### PR TITLE
update AOTConfig params for functionalization of inference

### DIFF
--- a/spmd/compiler/aot_function_patch.py
+++ b/spmd/compiler/aot_function_patch.py
@@ -113,6 +113,7 @@ def patched_aot_function(
         decompositions=decompositions,  # type:ignore[arg-type]
         num_params_buffers=num_params_buffers,
         aot_id=next(AOT_COUNTER),
+        keep_inference_input_mutations=True,
     )
     cached_res = None
 


### PR DESCRIPTION
AOT pushed an update that adds a param related to handling mutations of the graph during inference. 
Unfortunately while they updated inductor for it, they did not add a default param and so running with latest PT will err out. 
This PR just adds the new param for patched_aot_function.py so we can continue as before. 