### PR TITLE
Fix #752: update PyTorch version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch >= 1.12.0.dev0
+torch >= 1.13.0
 packaging >= 21.3


### PR DESCRIPTION
torch._subclasses requires PyTorch 1.13