### PR TITLE
Introduce pippy.all_compile

### DIFF
--- a/.github/workflows/pippy_gpu_tests.sh
+++ b/.github/workflows/pippy_gpu_tests.sh
@@ -36,7 +36,7 @@ python3 test/local_test_forward.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 test/local_test_forward_backward.py --replicate ${REPLICATE} -s ${SCHEDULE}
 python3 test/local_test_compile.py -s ${SCHEDULE}
 python3 examples/hf/gpt2/pippy_gpt2.py --replicate ${REPLICATE} -s ${SCHEDULE}
-python3 examples/gspmd/pippy_gspmd.py --replicate ${REPLICATE} -s ${SCHEDULE}
+python3 examples/gspmd/pippy_gspmd.py -s ${SCHEDULE}
 
 # Run flaky integration tests
 python3 test/local_test_ddp.py --replicate ${REPLICATE} -s ${SCHEDULE}

--- a/pippy/IR.py
+++ b/pippy/IR.py
@@ -1060,11 +1060,14 @@ class Pipe(torch.nn.Module):
         submod = split_gm_children[stage_id]
 
         # HACK: reusing defer init path in PipelineDriver
-        def materialize_stage(target: str) -> torch.nn.Module:
-            logging.info(f"Locally initializing {target}")
-            return self.split_gm.get_submodule(target)
+        def exported_stage(target: str) -> torch.nn.Module:
+            logging.info(f"Retrieving exported {target}")
+            assert self.split_gm.get_submodule(target) is submod
+            return submod
 
-        setattr(Pipe, "materialize_stage", materialize_stage)
+        if not hasattr(Pipe, "materialize_stage"):
+            setattr(Pipe, "materialize_stage", exported_stage)
+
         return submod
 
 

--- a/pippy/__init__.py
+++ b/pippy/__init__.py
@@ -11,7 +11,7 @@ from pippy.IR import (
 from pippy.PipelineDriver import PipelineDriverFillDrain, PipelineDriver1F1B
 from pippy.ModelSplit import split_on_size_threshold, split_into_equal_size
 from pippy.utils import run_pippy
-from pippy.compile import compile, create_default_args
+from pippy.compile import compile, all_compile, create_default_args
 
 
 __all__ = [
@@ -28,5 +28,6 @@ __all__ = [
     "split_into_equal_size",
     "split_on_size_threshold",
     "compile",
+    "all_compile",
     "create_default_args",
 ]

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -13,7 +13,6 @@ from pippy.microbatch import LossReducer, sum_reducer
 from pippy.utils import get_device, get_pp_rank, get_rank, pp_group_barrier
 
 import torch
-import torch.distributed.rpc as rpc
 
 
 PIPELINE_SCHEDULE_DRIVERS = {

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -10,8 +10,10 @@ from pippy.PipelineDriver import (
 import pippy.fx as fx
 from pippy.IR import MultiUseParameterConfig, Pipe
 from pippy.microbatch import LossReducer, sum_reducer
+from pippy.utils import pp_group_barrier
 
 import torch
+import torch.distributed.rpc as rpc
 
 
 PIPELINE_SCHEDULE_DRIVERS = {
@@ -36,13 +38,48 @@ def create_default_args(
     return default_kwargs
 
 
-def compile(
+def get_rank():
+    worker_info = rpc.get_worker_info()
+    logging.debug(worker_info)
+    return worker_info.id
+
+
+def get_device():
+    worker_info = rpc.get_worker_info()
+    agent = rpc._get_current_rpc_agent()
+    dev_map = agent._get_device_map(worker_info)
+    logging.debug(dev_map)
+    if len(dev_map) != 1:
+        raise AssertionError(
+            f"Expecting one device for RPC worker {worker_info}, "
+            f"but got {dev_map}"
+        )
+    src_dev = next(iter(dev_map))
+    dst_dev = dev_map[src_dev]
+    if src_dev != dst_dev:
+        raise AssertionError(
+            f"Expecting one device for RPC worker {worker_info}, "
+            f"but got {dev_map}"
+        )
+    return src_dev
+
+
+def get_pp_rank(rank, ranks):
+    for index, r in enumerate(ranks):
+        if rank == r:
+            return index
+    raise ValueError(
+        f"Rank {rank} not in ranks {ranks}"
+    )
+
+
+def _compile(
+    all_compile: bool,
     mod: torch.nn.Module,
     num_ranks: int,
     num_chunks: int,
     schedule: Optional[str] = "FillDrain",
     split_policy: Optional[Callable[[fx.GraphModule], fx.GraphModule]] = None,
-    rank: int = None,
     ranks: List[int] = None,
     tracer=None,
     loss_reducer: LossReducer = sum_reducer,
@@ -53,6 +90,16 @@ def compile(
     _debug_mask_minibatches: bool = False,
     **kwargs,
 ):
+    if ranks is None:
+        ranks = list(range(num_ranks))
+
+    if all_compile:
+        rank = get_rank()
+        device = get_device()
+        pp_rank = get_pp_rank(rank, ranks)
+    else:
+        pp_rank = 0
+
     # If a param will be used in multiple pipeline stages, we default the strategy to REPLICATE'ing the param across
     # stages instead of TRANSMIT'ting it
     multi_use_param_spec = MultiUseParameterConfig.REPLICATE
@@ -73,25 +120,110 @@ def compile(
         split_policy=split_policy,
         **kwargs,
     )
-    logging.info(pipe_model.split_gm)
 
-    logging.info("[PiPPy] Creating pipeline driver ...")
-    if schedule not in PIPELINE_SCHEDULE_DRIVERS:
-        raise ValueError(
-            f"Unknown pipeline schedule: {schedule}. "
-            f"Please select from {PIPELINE_SCHEDULE_DRIVERS.keys()}"
+    if all_compile:
+        pipe_model.defer_stage_init(device)
+        stage_mod = pipe_model.export(pp_rank)
+        # Make sure every rank has deferred its stage init before master creates the driver
+        # TODO: accepting ranks as argument here
+        pp_group_barrier()
+
+    if pp_rank == 0:
+        logging.info(pipe_model.split_gm)
+
+        logging.info("[PiPPy] Creating pipeline driver ...")
+        if schedule not in PIPELINE_SCHEDULE_DRIVERS:
+            raise ValueError(
+                f"Unknown pipeline schedule: {schedule}. "
+                f"Please select from {PIPELINE_SCHEDULE_DRIVERS.keys()}"
+            )
+        pipeline_driver = PIPELINE_SCHEDULE_DRIVERS[schedule](
+            pipe_model,
+            num_chunks,
+            num_ranks,
+            all_ranks=ranks,
+            args_chunk_spec=args_chunk_spec,
+            kwargs_chunk_spec=kwargs_chunk_spec,
+            output_chunk_spec=output_chunk_spec,
+            checkpoint=checkpoint,
+            loss_reducer=loss_reducer,
+            _debug_mask_minibatches=_debug_mask_minibatches,
         )
-    pipeline_driver = PIPELINE_SCHEDULE_DRIVERS[schedule](
-        pipe_model,
-        num_chunks,
+
+    if not all_compile:
+        return pipeline_driver
+
+    if pp_rank == 0:
+        return pipeline_driver, stage_mod
+    else:
+        return None, stage_mod
+
+
+def compile(
+    mod: torch.nn.Module,
+    num_ranks: int,
+    num_chunks: int,
+    schedule: Optional[str] = "FillDrain",
+    split_policy: Optional[Callable[[fx.GraphModule], fx.GraphModule]] = None,
+    ranks: List[int] = None,
+    tracer=None,
+    loss_reducer: LossReducer = sum_reducer,
+    args_chunk_spec=None,
+    kwargs_chunk_spec=None,
+    output_chunk_spec=None,
+    checkpoint=False,
+    _debug_mask_minibatches: bool = False,
+    **kwargs,
+):
+    return _compile(
+        False,
+        mod,
         num_ranks,
-        all_ranks=ranks,
+        num_chunks,
+        schedule=schedule,
+        split_policy=split_policy,
+        ranks=ranks,
+        tracer=tracer,
+        loss_reducer=loss_reducer,
         args_chunk_spec=args_chunk_spec,
         kwargs_chunk_spec=kwargs_chunk_spec,
         output_chunk_spec=output_chunk_spec,
         checkpoint=checkpoint,
-        loss_reducer=loss_reducer,
         _debug_mask_minibatches=_debug_mask_minibatches,
+        **kwargs,
     )
 
-    return pipeline_driver
+
+def all_compile(
+    mod: torch.nn.Module,
+    num_ranks: int,
+    num_chunks: int,
+    schedule: Optional[str] = "FillDrain",
+    split_policy: Optional[Callable[[fx.GraphModule], fx.GraphModule]] = None,
+    ranks: List[int] = None,
+    tracer=None,
+    loss_reducer: LossReducer = sum_reducer,
+    args_chunk_spec=None,
+    kwargs_chunk_spec=None,
+    output_chunk_spec=None,
+    checkpoint=False,
+    _debug_mask_minibatches: bool = False,
+    **kwargs,
+):
+    return _compile(
+        True,
+        mod,
+        num_ranks,
+        num_chunks,
+        schedule=schedule,
+        split_policy=split_policy,
+        ranks=ranks,
+        tracer=tracer,
+        loss_reducer=loss_reducer,
+        args_chunk_spec=args_chunk_spec,
+        kwargs_chunk_spec=kwargs_chunk_spec,
+        output_chunk_spec=output_chunk_spec,
+        checkpoint=checkpoint,
+        _debug_mask_minibatches=_debug_mask_minibatches,
+        **kwargs,
+    )

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -68,9 +68,7 @@ def get_pp_rank(rank, ranks):
     for index, r in enumerate(ranks):
         if rank == r:
             return index
-    raise ValueError(
-        f"Rank {rank} not in ranks {ranks}"
-    )
+    raise ValueError(f"Rank {rank} not in ranks {ranks}")
 
 
 def _compile(

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -106,12 +106,13 @@ def tp_transports():
     return ["shm", "uv"] if has_efa() else None
 
 
-# A barrier util for pipeline dimension
 global _pp_group_barrier
+# Defined later in `run_worker` (triggered via `run_pippy`)
 
 
+# A barrier util for pipeline dimension
 def pp_group_barrier():
-    _pp_group_barrier()
+    _pp_group_barrier()  # type: ignore[name-defined]
 
 
 def run_pippy(run_func, args, *extra_args):
@@ -246,7 +247,6 @@ def run_worker(rank, run_func, args, *extra_args):
     )
 
     # A barrier util for pipeline dimension
-    # Defined in this function (via `run_pippy`)
     global _pp_group_barrier
 
     # ProcessGroupGloo cannot create group with strided ranks, e.g. [0, 2, 4, 6, ...]

--- a/pippy/utils.py
+++ b/pippy/utils.py
@@ -2,6 +2,7 @@
 import os
 import socket
 import logging
+from typing import List
 
 # Pinning process to a separate GPU if not yet done by launch script
 # Notes:
@@ -41,6 +42,48 @@ else:
     print(f"Unsupported PIPPY_VERBOSITY level: {PIPPY_VERBOSITY}")
 
 
+def get_rank() -> int:
+    worker_info = rpc.get_worker_info()
+    logging.debug(worker_info)
+    return worker_info.id
+
+
+def get_device() -> torch.device:
+    worker_info = rpc.get_worker_info()
+    agent = rpc._get_current_rpc_agent()
+    dev_map = agent._get_device_map(worker_info)
+    logging.debug(dev_map)
+    num_devs = len(dev_map)
+
+    if num_devs == 0:
+        logging.debug("Empty device mapping, assuming device type to be cpu")
+        device = torch.device("cpu")
+    elif num_devs != 1:
+        raise AssertionError(
+            f"Expecting at most one device for RPC worker {worker_info}, "
+            f"but got device map of length {num_devs}: {dev_map}"
+        )
+    else:
+        src_dev = next(iter(dev_map))
+        dst_dev = dev_map[src_dev]
+        if src_dev != dst_dev:
+            raise AssertionError(
+                f"Expecting at most one device for RPC worker {worker_info}, "
+                f"but got {dev_map}"
+            )
+        device = src_dev
+
+    logging.info(f"Found device {device} for rank {worker_info.id}")
+    return device
+
+
+def get_pp_rank(rank: int, ranks: List[int]) -> int:
+    for index, r in enumerate(ranks):
+        if rank == r:
+            return index
+    raise ValueError(f"Rank {rank} not in ranks {ranks}")
+
+
 def has_efa() -> bool:
     try:
         import subprocess
@@ -61,6 +104,10 @@ def has_efa() -> bool:
 
 def tp_transports():
     return ["shm", "uv"] if has_efa() else None
+
+
+# A barrier util for pipeline dimension
+global _pp_group_barrier
 
 
 def pp_group_barrier():
@@ -199,6 +246,7 @@ def run_worker(rank, run_func, args, *extra_args):
     )
 
     # A barrier util for pipeline dimension
+    # Defined in this function (via `run_pippy`)
     global _pp_group_barrier
 
     # ProcessGroupGloo cannot create group with strided ranks, e.g. [0, 2, 4, 6, ...]


### PR DESCRIPTION
The GSPMD equivalent of `pippy.compile`.

`pippy.all_compile` enables all ranks to call into it and would perform stage-local module initialization.

The all_compile output is a little bit different than compile -- it returns not just the driver, but also the stage module, i.e.
```
pipe_driver, stage_mod = pippy.all_compile(
    mod,
    ...
)
```
For non-master rank, `pipe_driver` is return as `None`.

So for the data run, user would need an `if`:
```
if pipe_driver:
    pipe_driver(**input_dict)
```