### PR TITLE
Use cond var instead of pp_group_barrier

### DIFF
--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -10,7 +10,7 @@ from pippy.PipelineDriver import (
 import pippy.fx as fx
 from pippy.IR import MultiUseParameterConfig, Pipe
 from pippy.microbatch import LossReducer, sum_reducer
-from pippy.utils import get_device, get_pp_rank, get_rank, pp_group_barrier
+from pippy.utils import get_device, get_pp_rank, get_rank
 
 import torch
 

--- a/pippy/compile.py
+++ b/pippy/compile.py
@@ -90,9 +90,6 @@ def _compile(
         device = get_device()
         pipe_model.defer_stage_init(device)
         stage_mod = pipe_model.export(pp_rank)
-        # Make sure every rank has deferred its stage init before master creates the driver
-        # TODO: accepting ranks as argument here
-        pp_group_barrier()
 
     if pp_rank == 0:
         logging.info(pipe_model.split_gm)


### PR DESCRIPTION
`pp_group_barrier` is only available via `run_pippy` util.
This PR provides a generic solution for users not using `run_pippy`.
`RankWorker` would wait until the local `Pipe` has attribute `materialize_stage`.