### PR TITLE
[checkpoint] Add fsspec to spmd dependency

### DIFF
--- a/spmd/requirements.txt
+++ b/spmd/requirements.txt
@@ -1,5 +1,6 @@
 # Python dependencies required for release
 expecttest
+fsspec
 numpy
 pyyaml
 

--- a/spmd/setup.py
+++ b/spmd/setup.py
@@ -47,6 +47,7 @@ requirements = [
     # It can be installed as a binary or from source.
     "torch>=1.14.0.dev",
     "expecttest",
+    "fsspec",
     "numpy",
     "pyyaml",
 ]


### PR DESCRIPTION
Context: XLA folks are experimenting with DCP and want to try FSSpec read/write. We want to move the FsspecWriter/Reader in Tau so they can try it right away, and this would require adding FSSpec as a dependency for spmd. 